### PR TITLE
Fix for the `enoughValueHasBeenSelected` function

### DIFF
--- a/packages/module/src/core/CIP2.ts
+++ b/packages/module/src/core/CIP2.ts
@@ -77,7 +77,7 @@ const enoughValueHasBeenSelected = (
         .reduce((selectedQuantity, utxo) => {
           const utxoQuantity = utxo.output.amount
             .reduce(
-              (quantity, a) => quantity.checked_add(csl.BigNum.from_str(a.quantity)),
+              (quantity, a) => quantity.checked_add(csl.BigNum.from_str(asset.unit === a.unit ? a.quantity : '0')),
               csl.BigNum.from_str('0'),
             );
 


### PR DESCRIPTION
This is a fix for this issue: https://github.com/MeshJS/mesh/issues/85

The `enoughValueHasBeenSelected` is currently reducing all amount quantities in each UTXO, when it should only be reducing amount quantities where it's unit matches the current passed in `asset.unit` value.