### PR TITLE
Fix type issue

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/react.js",
       "require": "./dist/react.cjs"
     }


### PR DESCRIPTION
Was getting a typescript error when using pnpm as the package manager. 

```
There are types at '.../node_modules/@meshsdk/react/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@meshsdk/react' library may need to update its package.json or typings.
```

The types field in package.json is no longer used if there is an exports field: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts