### PR TITLE
Fix type issue at build

### DIFF
--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -48,7 +48,8 @@
   "exports": {
     ".": {
       "import": "./dist/core.js",
-      "require": "./dist/core.cjs"
+      "require": "./dist/core.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes an issue where typescript types aren't pulled from "typings" if "exports" is also defined.