### PR TITLE
feat: add setTxRefInputs method

### DIFF
--- a/packages/module/src/transaction/transaction.service.ts
+++ b/packages/module/src/transaction/transaction.service.ts
@@ -547,6 +547,22 @@ export class Transaction {
     return this;
   }
 
+  /**
+   * Sets the reference inputs for the transaction.
+   *
+   * @param {UTxO[]} inputs The reference inputs to set.
+   * @returns {Transaction} The transaction.
+   */
+  setTxRefInputs(inputs: UTxO[]): Transaction {
+    inputs
+      .map((input) => toTxUnspentOutput(input))
+      .forEach((utxo) => {
+        this._txBuilder.add_reference_input(utxo.input())
+      });
+
+    return this;
+  }
+
   withdrawRewards(rewardAddress: string, lovelace: string): Transaction {
     const address = toRewardAddress(rewardAddress);
 


### PR DESCRIPTION
Hi!,

This is a quite simple addition. I added the method `setTxRefInputs` in order to add reference inputs to the transaction. I tried to implement the tests but I didn't find where to do it. We can use this PR to communicate me further actions.