### PR TITLE
fix: redeem value with an inline datum

### DIFF
--- a/packages/module/src/transaction/transaction.service.ts
+++ b/packages/module/src/transaction/transaction.service.ts
@@ -250,7 +250,7 @@ export class Transaction {
   @Checkpoint()
   redeemValue(options: {
     value: UTxO, script: PlutusScript | UTxO,
-    datum: Data | UTxO, redeemer?: Action,
+    datum?: Data | UTxO, redeemer?: Action,
   }): Transaction {
     const redeemer: Action = {
       tag: 'SPEND',
@@ -264,11 +264,20 @@ export class Transaction {
     };
 
     const utxo = toTxUnspentOutput(options.value);
-    const witness = csl.PlutusWitness.new_with_ref(
-      buildPlutusScriptSource(options.script),
-      buildDatumSource(options.datum),
-      toRedeemer(redeemer),
-    );
+    let witness: csl.PlutusWitness;
+    if (options.datum) {
+      witness = csl.PlutusWitness.new_with_ref(
+        buildPlutusScriptSource(options.script),
+        buildDatumSource(options.datum),
+        toRedeemer(redeemer),
+      );
+    } else {
+      witness = csl.PlutusWitness.new_with_ref_without_datum(
+        buildPlutusScriptSource(options.script),
+        toRedeemer(redeemer),
+      );
+    }
+
 
     this._txInputsBuilder.add_plutus_script_input(
       witness, utxo.input(), utxo.output().amount(),


### PR DESCRIPTION
I opened this issue: https://github.com/Emurgo/cardano-serialization-lib/issues/650 but I immediately closed it. Because I realised that the CSL has a special way to create a Plutus Witness without datum:

```rust
impl PlutusWitness {

...
    pub fn new_with_ref(
        script: &PlutusScriptSource,
        datum: &DatumSource,
        redeemer: &Redeemer,
    ) -> Self {
        Self {
            script: script.0.clone(),
            datum: Some(datum.0.clone()),
            redeemer: redeemer.clone(),
        }
    }

    pub fn new_without_datum(script: &PlutusScript, redeemer: &Redeemer) -> Self {
        Self {
            script: PlutusScriptSourceEnum::Script(script.clone()),
            datum: None,
            redeemer: redeemer.clone(),
        }
    }

    pub fn new_with_ref_without_datum(script: &PlutusScriptSource, redeemer: &Redeemer) -> Self {
        Self {
            script: script.0.clone(),
            datum: None,
            redeemer: redeemer.clone(),
        }
    }

...
}
```
As it was programmed, if you set a UTxO in the datum of the `redeemValue`function, the UTxO will be added as a reference input. So, there wasn't any way to add a script UTxO with an inline datum.

My change add the option to have an undefined datum which means that you are relying in the inline datum of the script UTxO.

This PR makes some parts of the documentation obsolate or incomplete.