### PR TITLE
always use the newest package version

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -34,7 +34,7 @@
     "vitest": "0.28.4"
   },
   "peerDependencies": {
-    "@meshsdk/core": "1.5.6"
+    "@meshsdk/core": "*"
   },
   "dependencies": {
     "@harmoniclabs/plu-ts": "0.2.2"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
     "vite": "3.1.4"
   },
   "peerDependencies": {
-    "@meshsdk/core": "1.5.6",
+    "@meshsdk/core": "*",
     "react-dom": "17.x || 18.x",
     "react": "17.x || 18.x"
   },


### PR DESCRIPTION
Inside this monorepo, one package should use the newest version of another package in this monorepo.

Otherwise, the dependency would have to be updated manually or is simply outdated, as is currently the case.