### PR TITLE
Add JSON.stringify to enable error on  browser.service.ts

### DIFF
--- a/packages/module/src/wallet/browser.service.ts
+++ b/packages/module/src/wallet/browser.service.ts
@@ -39,7 +39,7 @@ export class BrowserWallet implements IInitiator, ISigner, ISubmitter {
 
       throw new Error(`Couldn't create an instance of wallet: ${walletName}`);
     } catch (error) {
-      throw new Error(`[BrowserWallet] An error occurred during enable: ${error}.`);
+      throw new Error(`[BrowserWallet] An error occurred during enable: ${JSON.stringify(error)}.`);
     }
   }
 


### PR DESCRIPTION
Add JSON.stringify to enable try/catch error handling

- errors are currently coming back with [Object object] in the message string