### PR TITLE
fix resolve input signer implementation

### DIFF
--- a/packages/core/src/wallet/embedded.service.ts
+++ b/packages/core/src/wallet/embedded.service.ts
@@ -382,9 +382,11 @@ export class EmbeddedWallet {
               u.input.txHash === inputHash.to_hex()
           ) !== undefined
             ? paymentKeyHash
-            : 'OUR_PRINCESS_IS_IN_ANOTHER_CASTLE';
+            : undefined;
 
-        return resolveTxInputsSigners(inputs, [...signers, signer], index + 1);
+        const finalSigners = signer ? [...signers, signer] : signers;
+
+        return resolveTxInputsSigners(inputs, finalSigners, index + 1);
       };
 
       const resolveRequiredSigners = (


### PR DESCRIPTION
Wallet signing has this weird behaviour where if it cannot find a particular tx body utxo in a wallet's available utxos, it will append a weird payment key. I've removed this logic, and just skip over any tx body utxos it cannot find in wallet.