### PR TITLE
feat: add tests for MeshTxBuilder constructor and reset method

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,8 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "11.1.6",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
     "rollup": "4.18.0",
     "tslib": "2.6.3",
     "typedoc": "0.25.13",

--- a/packages/core/src/transaction/meshTxBuilder/meshTxBuilder.spec.ts
+++ b/packages/core/src/transaction/meshTxBuilder/meshTxBuilder.spec.ts
@@ -1,5 +1,21 @@
-import { describe, it } from 'vitest';
+import { describe, it, beforeEach } from 'vitest';
+import { MeshTxBuilderCore } from './meshTxBuilderCore';
+import { correctInitState, setupMockTxBuilder } from './testUtils';
 
-describe('Mesh Tx Builder Service', () => {
-  it('should build transaction', () => { });
+describe('MeshTxBuilderCore', () => {
+  let txBuilder: MeshTxBuilderCore;
+
+  beforeEach(() => {
+    txBuilder = new MeshTxBuilderCore();
+  });
+
+  it('should initialize all properties to their default values in the constructor', () => {
+    correctInitState(txBuilder);
+  });
+
+  it('should reset all properties to their initial state when reset method is called', () => {
+    setupMockTxBuilder(txBuilder);
+    txBuilder.reset();
+    correctInitState(txBuilder);
+  });
 });

--- a/packages/core/src/transaction/meshTxBuilder/testUtils.ts
+++ b/packages/core/src/transaction/meshTxBuilder/testUtils.ts
@@ -1,0 +1,74 @@
+import { MeshTxBuilderCore } from './meshTxBuilderCore';
+import { DEFAULT_PROTOCOL_PARAMETERS } from '@mesh/common/constants';
+import { Protocol } from '@mesh/common/types';
+import { MintItem, PubKeyTxIn, RefTxIn } from './type';
+import { expect } from 'vitest';
+
+export const correctInitState = (txBuilder: MeshTxBuilderCore): void => {
+    expect(txBuilder.txHex).toBe('');
+    expect(txBuilder.txBuilder).toBeDefined();
+    expect(txBuilder.txEvaluationMultiplier).toBe(1.1);
+    expect(txBuilder['_protocolParams']).toEqual(DEFAULT_PROTOCOL_PARAMETERS);
+    expect(txBuilder['addingScriptInput']).toBeFalsy();
+    expect(txBuilder['addingPlutusMint']).toBeFalsy();
+    expect(txBuilder['meshTxBuilderBody']).toBeDefined();
+    expect(txBuilder['mintItem']).toBeUndefined();
+    expect(txBuilder['txInQueueItem']).toBeUndefined();
+    expect(txBuilder['collateralQueueItem']).toBeUndefined();
+    expect(txBuilder['refScriptTxInQueueItem']).toBeUndefined();
+};
+
+export const setupMockTxBuilder = (txBuilder: MeshTxBuilderCore): void => {
+    txBuilder.txHex = 'DummyHex';
+    txBuilder.txEvaluationMultiplier = 2.0;
+    txBuilder['_protocolParams'] = MOCK_PROTOCOL_PARAMETERS;
+    txBuilder['addingScriptInput'] = true;
+    txBuilder['addingPlutusMint'] = true;
+    txBuilder['mintItem'] = MOCK_MINT_ITEM;
+    txBuilder['txInQueueItem'] = MOCK_TX_IN;
+    txBuilder['collateralQueueItem'] = MOCK_TX_IN;
+    txBuilder['refScriptTxInQueueItem'] = MOCK_REF_TX_IN;
+};
+
+export const MOCK_PROTOCOL_PARAMETERS: Protocol = {
+    epoch: 10,
+    coinsPerUTxOSize: '4312',
+    priceMem: 0.0573,
+    priceStep: 0.0000730,
+    minFeeA: 45,
+    minFeeB: 155385,
+    keyDeposit: '2100000',
+    maxTxSize: 16384,
+    maxValSize: '5000',
+    poolDeposit: '500000000',
+    maxCollateralInputs: 4,
+    decentralisation: 0,
+    maxBlockSize: 98304,
+    collateralPercent: 150,
+    maxBlockHeaderSize: 1100,
+    minPoolCost: '320000000',
+    maxTxExMem: '19000000',
+    maxTxExSteps: '11000000000',
+    maxBlockExMem: '90000000',
+    maxBlockExSteps: '50000000000',
+};
+
+export const MOCK_MINT_ITEM: MintItem = {
+    type: 'Plutus',
+    policyId: 'MockPolicyId',
+    assetName: 'AssetName',
+    amount: '1',
+};
+
+export const MOCK_TX_IN: PubKeyTxIn = {
+    type: 'PubKey',
+    txIn: {
+        txHash: 'string',
+        txIndex: 0,
+    },
+};
+
+export const MOCK_REF_TX_IN: RefTxIn = {
+    txHash: 'MockTxHash',
+    txIndex: 0,
+};


### PR DESCRIPTION
- Added test for MeshTxBuilder constructor to verify initial state.
- Added test for MeshTxBuilder reset() method to ensure it correctly resets state

Note: This is my first PR on this repo, and I am open to feedback to change the code to respect the repository's conventions, nomenclature, and best practices.