### PR TITLE
[StakeButton] delegateStake when account active, otherwise registerStake

### DIFF
--- a/packages/mesh-react/src/stake-button/index.tsx
+++ b/packages/mesh-react/src/stake-button/index.tsx
@@ -102,26 +102,28 @@ const Delegate = ({
     setProcessing(false);
   };
 
-  // const delegateStake = async () => {
-  //   setProcessing(true);
-  //   setDone(false);
-  //   try {
-  //     if (rewardAddress) {
-  //       const tx = new Transaction({ initiator: wallet }).delegateStake(
-  //         rewardAddress,
-  //         poolId,
-  //       );
+  const delegateStake = async () => {
+    setProcessing(true);
+    setDone(false);
+    try {
+      if (rewardAddress) {
+        const tx = new Transaction({ initiator: wallet })
+          .delegateStake(rewardAddress, poolId);
 
-  //       const unsignedTx = await tx.build();
-  //       const signedTx = await wallet.signTx(unsignedTx);
-  //       await wallet.submitTx(signedTx);
-  //       setDone(true);
-  //     }
-  //   } catch (error) {
-  //     setError(error);
-  //   }
-  //   setProcessing(false);
-  // };
+        const unsignedTx = await tx.build();
+        const signedTx = await wallet.signTx(unsignedTx);
+        await wallet.submitTx(signedTx);
+
+        if (onDelegated) {
+          onDelegated();
+        }
+        setDone(true);
+      }
+    } catch (error) {
+      setError(error);
+    }
+    setProcessing(false);
+  };
 
   useEffect(() => {
     checkAccountStatus();
@@ -141,8 +143,7 @@ const Delegate = ({
     return accountInfo.poolId === poolId ? (
       <span>Stake Delegated</span>
     ) : (
-      // <span onClick={delegateStake}>Delegate Stake</span>
-      <span onClick={registerAddress}>Begin Staking</span>
+      <span onClick={delegateStake}>Begin Staking</span>
     );
   }
 


### PR DESCRIPTION
## Summary

1. Re-enables the original delegateStake function
2. Brings it in sync with the registerAddress function (e.g. `onDelgated` logic)
3. Restores conditional behavior to delegateStake for already active accounts, and registerAddress for non active accounts.


## Affect components

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/provider`
- [X] `@meshsdk/react`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

Closes #355 

## Checklist

- [X] My code is appropriately commented and includes relevant documentation, if necessary
- [X] I have added tests to cover my changes, if necessary
- [X] I have updated the documentation, if necessary
- [X] All new and existing tests pass (i.e. `npm run test`)
- [X] The build is pass (i.e. `npm run build`)

* I've marked everything as pass, deeming "not necessary" where applicable, as this mostly re-enables existing logic and is documented and fixes a bug introduced when the code/logic was removed.
* Existing tests are not passing, but that comes from the main branch. I do not observe any new test failures introduced from this branch.


## Additional Information

N/A