### PR TITLE
Update ref script getters in  providers 

### DIFF
--- a/packages/mesh-core-cst/src/index.ts
+++ b/packages/mesh-core-cst/src/index.ts
@@ -6,6 +6,7 @@ export * from "./resolvers";
 export * from "./serializer";
 export * from "./stricahq";
 export * from "./utils";
+export * from "./plutus-tools";
 
 export * as CardanoSDKUtil from "@cardano-sdk/util";
 export * as Crypto from "@cardano-sdk/crypto";

--- a/packages/mesh-core-cst/src/plutus-tools/index.ts
+++ b/packages/mesh-core-cst/src/plutus-tools/index.ts
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2024 Evgenii Lisitskii
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -61,7 +61,7 @@ export type OutputEncoding = "SingleCBOR" | "DoubleCBOR" | "PurePlutusScriptByte
  * - This function modifies the structure of the Plutus script by applying arguments, which can change its behavior when executed.
  * - The function assumes that the input arguments are in a compatible format (CBOR-encoded) and that the program is a valid Plutus script.
  */
-export const applyArgsToPlutusScript = (args: Uint8Array[], program: Uint8Array, outputEncoding: OutputEncoding): Uint8Array => {
+const applyArgsToPlutusScript = (args: Uint8Array[], program: Uint8Array, outputEncoding: OutputEncoding): Uint8Array => {
     const purePlutusBytes = getPurePlutusBytes(program);
     const parsedProgram = parseUPLC(purePlutusBytes, "flat");
     const decodedArgs = args.map((arg) => dataFromCbor(arg));
@@ -86,16 +86,18 @@ export const applyArgsToPlutusScript = (args: Uint8Array[], program: Uint8Array,
  *
  * @description
  * This function performs the following steps:
- * 1. Extracts the pure Plutus bytes from the input script.
+ * 1. Extracts the pure Plutus bytes in hex from the input script.
  * 2. Applies the specified encoding to the pure Plutus bytes.
  *
  * @note
  * - This function is useful for standardizing the format of Plutus scripts, ensuring they are in a consistent state for further processing or comparison.
  * - The normalization process does not modify the logical content of the script, only its representation.
  */
-export const normalizePlutusScript = (plutusScript: Uint8Array, encoding: OutputEncoding): Uint8Array => {
-    const purePlutusBytes = getPurePlutusBytes(plutusScript);
-    return applyEncoding(purePlutusBytes, encoding);
+export const normalizePlutusScript = (plutusScript: string, encoding: OutputEncoding): string => {
+    const bytes = Buffer.from(plutusScript, "hex");
+    const purePlutusBytes = getPurePlutusBytes(bytes);
+    const normalizedBytes = applyEncoding(purePlutusBytes, encoding);
+    return Buffer.from(normalizedBytes).toString("hex");
 }
 
 const hasSupportedPlutusVersion = (plutusScript: Uint8Array): boolean => {
@@ -112,8 +114,10 @@ const hasSupportedPlutusVersion = (plutusScript: Uint8Array): boolean => {
 
 const getPurePlutusBytes = (plutusScript: Uint8Array): Uint8Array => {
     let unwrappedScript = plutusScript;
+    let length = 0;
     try {
-        while (unwrappedScript.length >= 3) {
+        while (unwrappedScript.length >= 3 && length != unwrappedScript.length) {
+            length = unwrappedScript.length;
             if (hasSupportedPlutusVersion(unwrappedScript)) {
                 return unwrappedScript;
             }

--- a/packages/mesh-provider/src/koios.ts
+++ b/packages/mesh-provider/src/koios.ts
@@ -20,7 +20,7 @@ import {
 } from "@meshsdk/common";
 import {
   deserializeNativeScript,
-  fromNativeScript,
+  fromNativeScript, normalizePlutusScript,
   resolveRewardAddress,
   toScriptRef,
 } from "@meshsdk/core-cst";
@@ -500,12 +500,16 @@ export class KoiosProvider implements IFetcher, IListener, ISubmitter {
     kScriptRef: KoiosReferenceScript | undefined,
   ): string | undefined => {
     if (kScriptRef) {
-      const script = kScriptRef.type.startsWith("plutus")
-        ? <PlutusScript>{
-            code: kScriptRef.bytes,
-            version: kScriptRef.type.replace("plutus", ""),
-          }
-        : fromNativeScript(deserializeNativeScript(kScriptRef.bytes));
+      let script;
+      if(kScriptRef.type.startsWith("plutus")) {
+        const normalized = normalizePlutusScript(kScriptRef.bytes, "DoubleCBOR");
+        script = <PlutusScript>{
+          code: normalized,
+          version: kScriptRef.type.replace("plutus", ""),
+        }
+      } else {
+        script = fromNativeScript(deserializeNativeScript(kScriptRef.bytes));
+      }
 
       if (script) return toScriptRef(script).toCbor().toString();
     }


### PR DESCRIPTION
## Summary
This PR normalizes Plutus script references across different providers by standardizing their encoding using the new `normalizePlutusScript` function. The change ensures consistent script representation and prevents potential issues with script hash comparison.

## Affect components
- [x] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [x] `@meshsdk/core-cst`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. https://meshjs.dev/)
- [ ] Mesh CLI

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues
None specified

## Checklist
- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

## Additional Information
The key changes include:
1. Exporting plutus-tools utilities from core-cst package to make them available for providers
2. Modifying `normalizePlutusScript` to work with hex strings and enforce DoubleCBOR encoding for consistency
3. Updating script reference resolution in all providers (Blockfrost, Koios, Maestro, Yaci) to use normalized scripts
4. Adding infinite loop protection in plutus script bytes extraction
5. Adding error handling for missing script bytes in Maestro provider