### PR TITLE
set scriptSize of collateral inputs to 0 to bypass fetcher logic

### DIFF
--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,9 +34,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.14",
-    "@meshsdk/core": "1.7.14",
-    "@meshsdk/core-csl": "1.7.14"
+    "@meshsdk/common": "1.7.15",
+    "@meshsdk/core": "1.7.15",
+    "@meshsdk/core-csl": "1.7.15"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -38,7 +38,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.14",
+    "@meshsdk/common": "1.7.15",
     "@sidan-lab/sidan-csl-rs-browser": "0.9.5",
     "@sidan-lab/sidan-csl-rs-nodejs": "0.9.5",
     "json-bigint": "^1.0.0"

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -42,7 +42,7 @@
     "@harmoniclabs/cbor": "1.3.0",
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
-    "@meshsdk/common": "1.7.14",
+    "@meshsdk/common": "1.7.15",
     "@stricahq/bip32ed25519": "^1.1.0",
     "@stricahq/cbors": "^1.0.3",
     "pbkdf2": "^3.1.2"

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,13 +33,13 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.14",
-    "@meshsdk/core-csl": "1.7.14",
-    "@meshsdk/core-cst": "1.7.14",
-    "@meshsdk/provider": "1.7.14",
-    "@meshsdk/react": "1.7.14",
-    "@meshsdk/transaction": "1.7.14",
-    "@meshsdk/wallet": "1.7.14"
+    "@meshsdk/common": "1.7.15",
+    "@meshsdk/core-csl": "1.7.15",
+    "@meshsdk/core-cst": "1.7.15",
+    "@meshsdk/provider": "1.7.15",
+    "@meshsdk/react": "1.7.15",
+    "@meshsdk/transaction": "1.7.15",
+    "@meshsdk/wallet": "1.7.15"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.14",
-    "@meshsdk/core-cst": "1.7.14",
+    "@meshsdk/common": "1.7.15",
+    "@meshsdk/core-cst": "1.7.15",
     "@utxorpc/sdk": "0.6.2",
     "@utxorpc/spec": "0.10.1",
     "axios": "^1.7.2"

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "@meshsdk/common": "1.7.14",
-    "@meshsdk/transaction": "1.7.14",
-    "@meshsdk/wallet": "1.7.14"
+    "@meshsdk/common": "1.7.15",
+    "@meshsdk/transaction": "1.7.15",
+    "@meshsdk/wallet": "1.7.15"
   },
   "devDependencies": {
     "@meshsdk/configs": "*",

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.14",
-    "@meshsdk/core-csl": "1.7.14",
-    "@meshsdk/core-cst": "1.7.14",
+    "@meshsdk/common": "1.7.15",
+    "@meshsdk/core-csl": "1.7.15",
+    "@meshsdk/core-cst": "1.7.15",
     "json-bigint": "^1.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-transaction/src/mesh-tx-builder/index.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/index.ts
@@ -82,6 +82,11 @@ export class MeshTxBuilder extends MeshTxBuilderCore {
     }
     this.removeDuplicateInputs();
 
+    // We can set scriptSize of collaterals as 0, because the ledger ignores this for fee calculations
+    for (let collateral of this.meshTxBuilderBody.collaterals) {
+      collateral.txIn.scriptSize = 0;
+    }
+
     // Checking if all inputs are complete
     const { inputs, collaterals, mints } = this.meshTxBuilderBody;
     const incompleteTxIns = [...inputs, ...collaterals].filter(

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,10 +35,10 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.14",
-    "@meshsdk/core-csl": "1.7.14",
-    "@meshsdk/core-cst": "1.7.14",
-    "@meshsdk/transaction": "1.7.14",
+    "@meshsdk/common": "1.7.15",
+    "@meshsdk/core-csl": "1.7.15",
+    "@meshsdk/core-cst": "1.7.15",
+    "@meshsdk/transaction": "1.7.15",
     "@nufi/dapp-client-cardano": "0.3.5",
     "@nufi/dapp-client-core": "0.3.5"
   },

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your dApps on Cardano using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Collateral inputs were included in incomplete tx ins, affecting the need for a fetcher in offline transactions. Since any reference scripts in collateral inputs do not affect fee calculations, it is possible to directly set the scriptSize of collateral inputs to 0, bypassing the inclusion of these scripts for fee calculations.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [x] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

## Additional Information

