### PR TITLE
Use wrapper import for Bip32PublicKey object.

### DIFF
--- a/packages/mesh-core-cst/src/message-signing/check-signature.ts
+++ b/packages/mesh-core-cst/src/message-signing/check-signature.ts
@@ -1,8 +1,8 @@
 import { Credential } from "@cardano-sdk/core/dist/cjs/Cardano";
-import { Bip32PublicKey } from "@stricahq/bip32ed25519";
 
 import { DataSignature } from "@meshsdk/common";
 
+import { StricaBip32PublicKey } from "../stricahq";
 import {
   Address,
   BaseAddress,
@@ -26,7 +26,7 @@ export const checkSignature = (
   if (address) {
     let network = NetworkId.Mainnet;
     const paymentAddress = BaseAddress.fromAddress(Address.fromBech32(address));
-    const coseSign1PublicKey = new Bip32PublicKey(publicKeyBuffer);
+    const coseSign1PublicKey = new StricaBip32PublicKey(publicKeyBuffer);
 
     const credential: Credential = {
       hash: Hash28ByteBase16.fromEd25519KeyHashHex(


### PR DESCRIPTION
## Summary
I think I introduced an issue in a previous PR by using importing a CommonJS module incorrectly. I think instead it would be correct to import the Bip32PublicKey object with the proxy wrapper found in the wrapper.ts file.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [x] `@meshsdk/core-cst`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

> Please add the related issue here if any, e.g.:
>
> - https://github.com/MeshJS/mesh/issues/392

## Checklist

> Please ensure that your pull request meets the following criteria:

- [ ] My code is appropriately commented and includes relevant documentation, if necessary
- [ ] I have added tests to cover my changes, if necessary
- [ ] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

## Additional Information

> If you have any additional information or context to provide, such as screenshots, relevant issues, or other details, please include them here.
