### PR TITLE
Account index and key index fix in MeshWallet

### DIFF
--- a/packages/mesh-wallet/src/mesh/index.ts
+++ b/packages/mesh-wallet/src/mesh/index.ts
@@ -106,6 +106,11 @@ export class MeshWallet implements IInitiator, ISigner, ISubmitter {
   constructor(options: CreateMeshWalletOptions) {
     this._networkId = options.networkId;
 
+    if (options.fetcher) this._fetcher = options.fetcher;
+    if (options.submitter) this._submitter = options.submitter;
+    if (options.accountIndex) this._accountIndex = options.accountIndex;
+    if (options.keyIndex) this._keyIndex = options.keyIndex;
+
     switch (options.key.type) {
       case "root":
         this._wallet = new EmbeddedWallet({
@@ -143,11 +148,6 @@ export class MeshWallet implements IInitiator, ISigner, ISubmitter {
         this.buildAddressFromBech32Address(options.key.address);
         break;
     }
-
-    if (options.fetcher) this._fetcher = options.fetcher;
-    if (options.submitter) this._submitter = options.submitter;
-    if (options.accountIndex) this._accountIndex = options.accountIndex;
-    if (options.keyIndex) this._keyIndex = options.keyIndex;
   }
 
   /**
@@ -324,7 +324,12 @@ export class MeshWallet implements IInitiator, ISigner, ISubmitter {
     if (address === undefined) {
       address = this.getChangeAddress()!;
     }
-    return this._wallet.signData(address, payload);
+    return this._wallet.signData(
+      address,
+      payload,
+      this._accountIndex,
+      this._keyIndex,
+    );
   }
 
   /**


### PR DESCRIPTION
- set index numbers earlier in constructor
- send index numbers in signData

## Summary

`MeshWallet` is targeted to have the ability to access an account at any index generated from an HD mnemonic (or a root private key). But it was not able to access any account other than the first one.

1. After rearranging some lines of code, `MeshWallet` is now able to utilize the provided `accountIndex` and `keyIndex` when an instance is created, which was not the case before, because `getAddressesFromWallet()` was getting called before setting those indexes.
2. In `MeshWallet`'s `signData()`, the `accountIndex` and `keyIndex` are now being passed to the EmbeddedWallet's signData().

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/transaction`
- [x] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

Not any

## Checklist

> Please ensure that your pull request meets the following criteria:

- [ ] My code is appropriately commented and includes relevant documentation, if necessary
- [ ] I have added tests to cover my changes, if necessary
- [ ] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)
