### PR TITLE
Account index fix

### DIFF
--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,9 +34,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.18",
-    "@meshsdk/core": "1.7.18",
-    "@meshsdk/core-csl": "1.7.18"
+    "@meshsdk/common": "1.7.19",
+    "@meshsdk/core": "1.7.19",
+    "@meshsdk/core-csl": "1.7.19"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@meshsdk/configs": "*",
-    "@meshsdk/provider": "1.7.18",
+    "@meshsdk/provider": "1.7.19",
     "@types/json-bigint": "^1.0.4",
     "eslint": "^8.57.0",
     "ts-jest": "^29.1.4",
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.18",
+    "@meshsdk/common": "1.7.19",
     "@sidan-lab/sidan-csl-rs-browser": "0.9.6",
     "@sidan-lab/sidan-csl-rs-nodejs": "0.9.6",
     "json-bigint": "^1.0.0"

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -42,7 +42,7 @@
     "@harmoniclabs/cbor": "1.3.0",
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
-    "@meshsdk/common": "1.7.18",
+    "@meshsdk/common": "1.7.19",
     "@stricahq/bip32ed25519": "^1.1.0",
     "@stricahq/cbors": "^1.0.3",
     "pbkdf2": "^3.1.2"

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,13 +33,13 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.18",
-    "@meshsdk/core-csl": "1.7.18",
-    "@meshsdk/core-cst": "1.7.18",
-    "@meshsdk/provider": "1.7.18",
-    "@meshsdk/react": "1.7.18",
-    "@meshsdk/transaction": "1.7.18",
-    "@meshsdk/wallet": "1.7.18"
+    "@meshsdk/common": "1.7.19",
+    "@meshsdk/core-csl": "1.7.19",
+    "@meshsdk/core-cst": "1.7.19",
+    "@meshsdk/provider": "1.7.19",
+    "@meshsdk/react": "1.7.19",
+    "@meshsdk/transaction": "1.7.19",
+    "@meshsdk/wallet": "1.7.19"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.18",
-    "@meshsdk/core-cst": "1.7.18",
+    "@meshsdk/common": "1.7.19",
+    "@meshsdk/core-cst": "1.7.19",
     "@utxorpc/sdk": "0.6.2",
     "@utxorpc/spec": "0.10.1",
     "axios": "^1.7.2"

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "@meshsdk/common": "1.7.18",
-    "@meshsdk/transaction": "1.7.18",
-    "@meshsdk/wallet": "1.7.18"
+    "@meshsdk/common": "1.7.19",
+    "@meshsdk/transaction": "1.7.19",
+    "@meshsdk/wallet": "1.7.19"
   },
   "devDependencies": {
     "@meshsdk/configs": "*",

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.18",
-    "@meshsdk/core-csl": "1.7.18",
-    "@meshsdk/core-cst": "1.7.18",
+    "@meshsdk/common": "1.7.19",
+    "@meshsdk/core-csl": "1.7.19",
+    "@meshsdk/core-cst": "1.7.19",
     "json-bigint": "^1.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,10 +35,10 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.7.18",
-    "@meshsdk/core-csl": "1.7.18",
-    "@meshsdk/core-cst": "1.7.18",
-    "@meshsdk/transaction": "1.7.18",
+    "@meshsdk/common": "1.7.19",
+    "@meshsdk/core-csl": "1.7.19",
+    "@meshsdk/core-cst": "1.7.19",
+    "@meshsdk/transaction": "1.7.19",
     "@nufi/dapp-client-cardano": "0.3.5",
     "@nufi/dapp-client-core": "0.3.5"
   },

--- a/packages/mesh-wallet/src/mesh/index.ts
+++ b/packages/mesh-wallet/src/mesh/index.ts
@@ -106,6 +106,11 @@ export class MeshWallet implements IInitiator, ISigner, ISubmitter {
   constructor(options: CreateMeshWalletOptions) {
     this._networkId = options.networkId;
 
+    if (options.fetcher) this._fetcher = options.fetcher;
+    if (options.submitter) this._submitter = options.submitter;
+    if (options.accountIndex) this._accountIndex = options.accountIndex;
+    if (options.keyIndex) this._keyIndex = options.keyIndex;
+
     switch (options.key.type) {
       case "root":
         this._wallet = new EmbeddedWallet({
@@ -143,11 +148,6 @@ export class MeshWallet implements IInitiator, ISigner, ISubmitter {
         this.buildAddressFromBech32Address(options.key.address);
         break;
     }
-
-    if (options.fetcher) this._fetcher = options.fetcher;
-    if (options.submitter) this._submitter = options.submitter;
-    if (options.accountIndex) this._accountIndex = options.accountIndex;
-    if (options.keyIndex) this._keyIndex = options.keyIndex;
   }
 
   /**
@@ -324,7 +324,12 @@ export class MeshWallet implements IInitiator, ISigner, ISubmitter {
     if (address === undefined) {
       address = this.getChangeAddress()!;
     }
-    return this._wallet.signData(address, payload);
+    return this._wallet.signData(
+      address,
+      payload,
+      this._accountIndex,
+      this._keyIndex,
+    );
   }
 
   /**

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your dApps on Cardano using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
- set index numbers earlier in constructor
- send index numbers in signData

## Summary

`MeshWallet` is targeted to have the ability to access an account at any index generated from an HD mnemonic (or a root private key). But it was not able to access any account other than the first one.

1. After rearranging some lines of code, `MeshWallet` is now able to utilize the provided `accountIndex` and `keyIndex` when an instance is created, which was not the case before, because `getAddressesFromWallet()` was getting called before setting those indexes.
2. In `MeshWallet`'s `signData()`, the `accountIndex` and `keyIndex` are now being passed to the EmbeddedWallet's signData().

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/transaction`
- [x] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

Not any

## Checklist

> Please ensure that your pull request meets the following criteria:

- [ ] My code is appropriately commented and includes relevant documentation, if necessary
- [ ] I have added tests to cover my changes, if necessary
- [ ] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)
