### PR TITLE
feat: add tx chaining support in tx builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7909,16 +7909,14 @@
       }
     },
     "node_modules/@sidan-lab/sidan-csl-rs-browser": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@sidan-lab/sidan-csl-rs-browser/-/sidan-csl-rs-browser-0.9.18.tgz",
-      "integrity": "sha512-W0B1JbA5Jfrmcxdm1nC0TFYL2ezqJES6l+U/H0cT4zO2Ei8t6RoYfIkok3f75rGVfE6ywMW0h7ESV2C4Iam1kw==",
-      "license": "Apache-2.0"
+      "version": "0.9.21",
+      "resolved": "https://registry.npmjs.org/@sidan-lab/sidan-csl-rs-browser/-/sidan-csl-rs-browser-0.9.21.tgz",
+      "integrity": "sha512-oVF+L+rDM+stR2CYnYm7wpHgSt1IifVvrhs3DZGqKAwDH7oFdVbwyZeiQaUEH0nxt+/dqdj7nW2dbCXFBtUC2g=="
     },
     "node_modules/@sidan-lab/sidan-csl-rs-nodejs": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@sidan-lab/sidan-csl-rs-nodejs/-/sidan-csl-rs-nodejs-0.9.18.tgz",
-      "integrity": "sha512-dZt4ECAxhHap4jNLXvfY8oHRKFTnFm23nPz0jIDpZRP+SZX+SzJMfSQgXzT/xMnrFOjIZawMRuKwVXH5Bqx4iw==",
-      "license": "Apache-2.0"
+      "version": "0.9.21",
+      "resolved": "https://registry.npmjs.org/@sidan-lab/sidan-csl-rs-nodejs/-/sidan-csl-rs-nodejs-0.9.21.tgz",
+      "integrity": "sha512-Nkb/iB6D3GNvvSk4aPpL6i4Y3LwZi6C/Ogbb4OuHy756bl9vXTL+MlFkOO3flWZkB+IxwU1RKQe/xTJ/vnv7jg=="
     },
     "node_modules/@silentbot1/nat-api": {
       "version": "0.4.7",
@@ -11699,6 +11697,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15679,6 +15678,7 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/html-escaper": {
@@ -17518,6 +17518,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -19163,6 +19164,7 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
       "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -19590,6 +19592,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -19602,6 +19605,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -25317,6 +25321,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -25327,12 +25332,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -25343,6 +25350,7 @@
       "version": "3.0.21",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
       "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/speed-limiter": {
@@ -27724,6 +27732,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -28700,6 +28709,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -28713,6 +28723,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -28963,7 +28974,7 @@
     },
     "packages/mesh-common": {
       "name": "@meshsdk/common",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "bech32": "^2.0.0",
@@ -28980,11 +28991,11 @@
     },
     "packages/mesh-contract": {
       "name": "@meshsdk/contract",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.0",
-        "@meshsdk/core": "1.9.0-beta.0"
+        "@meshsdk/common": "1.9.0-beta.1",
+        "@meshsdk/core": "1.9.0-beta.1"
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
@@ -28995,15 +29006,15 @@
     },
     "packages/mesh-core": {
       "name": "@meshsdk/core",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.0",
-        "@meshsdk/core-cst": "1.9.0-beta.0",
-        "@meshsdk/provider": "1.9.0-beta.0",
-        "@meshsdk/react": "1.9.0-beta.0",
-        "@meshsdk/transaction": "1.9.0-beta.0",
-        "@meshsdk/wallet": "1.9.0-beta.0"
+        "@meshsdk/common": "1.9.0-beta.1",
+        "@meshsdk/core-cst": "1.9.0-beta.1",
+        "@meshsdk/provider": "1.9.0-beta.1",
+        "@meshsdk/react": "1.9.0-beta.1",
+        "@meshsdk/transaction": "1.9.0-beta.1",
+        "@meshsdk/wallet": "1.9.0-beta.1"
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
@@ -29014,12 +29025,12 @@
     },
     "packages/mesh-core-csl": {
       "name": "@meshsdk/core-csl",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.0",
-        "@sidan-lab/sidan-csl-rs-browser": "0.9.18",
-        "@sidan-lab/sidan-csl-rs-nodejs": "0.9.18",
+        "@meshsdk/common": "1.9.0-beta.1",
+        "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
+        "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
         "@types/base32-encoding": "^1.0.2",
         "base32-encoding": "^1.0.0",
         "bech32": "^2.0.0",
@@ -29027,7 +29038,7 @@
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
-        "@meshsdk/provider": "1.9.0-beta.0",
+        "@meshsdk/provider": "1.9.0-beta.1",
         "@types/json-bigint": "^1.0.4",
         "eslint": "^8.57.0",
         "ts-jest": "^29.1.4",
@@ -29037,7 +29048,7 @@
     },
     "packages/mesh-core-cst": {
       "name": "@meshsdk/core-cst",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@cardano-sdk/core": "^0.43.0",
@@ -29049,7 +29060,7 @@
         "@harmoniclabs/pair": "1.0.0",
         "@harmoniclabs/plutus-data": "1.2.4",
         "@harmoniclabs/uplc": "1.2.4",
-        "@meshsdk/common": "1.9.0-beta.0",
+        "@meshsdk/common": "1.9.0-beta.1",
         "@stricahq/bip32ed25519": "^1.1.0",
         "@stricahq/cbors": "^1.0.0",
         "@types/base32-encoding": "^1.0.2",
@@ -29071,11 +29082,11 @@
     },
     "packages/mesh-provider": {
       "name": "@meshsdk/provider",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.0",
-        "@meshsdk/core-cst": "1.9.0-beta.0",
+        "@meshsdk/common": "1.9.0-beta.1",
+        "@meshsdk/core-cst": "1.9.0-beta.1",
         "@utxorpc/sdk": "0.6.2",
         "@utxorpc/spec": "0.10.1",
         "axios": "^1.7.2"
@@ -29090,13 +29101,13 @@
     },
     "packages/mesh-react": {
       "name": "@meshsdk/react",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fabianbormann/cardano-peer-connect": "^1.2.18",
-        "@meshsdk/common": "1.9.0-beta.0",
-        "@meshsdk/transaction": "1.9.0-beta.0",
-        "@meshsdk/wallet": "1.9.0-beta.0",
+        "@meshsdk/common": "1.9.0-beta.1",
+        "@meshsdk/transaction": "1.9.0-beta.1",
+        "@meshsdk/wallet": "1.9.0-beta.1",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-icons": "^1.3.2",
@@ -29132,10 +29143,10 @@
     },
     "packages/mesh-svelte": {
       "name": "@meshsdk/svelte",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/core": "1.9.0-beta.0",
+        "@meshsdk/core": "1.9.0-beta.1",
         "bits-ui": "1.0.0-next.65"
       },
       "devDependencies": {
@@ -29161,11 +29172,11 @@
     },
     "packages/mesh-transaction": {
       "name": "@meshsdk/transaction",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.0",
-        "@meshsdk/core-cst": "1.9.0-beta.0",
+        "@meshsdk/common": "1.9.0-beta.1",
+        "@meshsdk/core-cst": "1.9.0-beta.1",
         "json-bigint": "^1.0.0"
       },
       "devDependencies": {
@@ -29178,12 +29189,12 @@
     },
     "packages/mesh-wallet": {
       "name": "@meshsdk/wallet",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.0",
-        "@meshsdk/core-cst": "1.9.0-beta.0",
-        "@meshsdk/transaction": "1.9.0-beta.0",
+        "@meshsdk/common": "1.9.0-beta.1",
+        "@meshsdk/core-cst": "1.9.0-beta.1",
+        "@meshsdk/transaction": "1.9.0-beta.1",
         "@simplewebauthn/browser": "^13.0.0"
       },
       "devDependencies": {
@@ -29196,7 +29207,7 @@
     },
     "scripts/mesh-cli": {
       "name": "meshjs",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "5.3.0",

--- a/packages/mesh-common/src/interfaces/evaluator.ts
+++ b/packages/mesh-common/src/interfaces/evaluator.ts
@@ -1,7 +1,9 @@
-import { Action } from "../types";
+import { Action, UTxO } from "../types";
 
 export interface IEvaluator {
   evaluateTx(
     tx: string,
+    additionalUtxos?: UTxO[],
+    additionalTxs?: string[],
   ): Promise<Omit<Action, "data">[]>;
 }

--- a/packages/mesh-common/src/types/transaction-builder/index.ts
+++ b/packages/mesh-common/src/types/transaction-builder/index.ts
@@ -37,6 +37,8 @@ export type MeshTxBuilderBody = {
     strategy: UtxoSelectionStrategy;
     includeTxFees: boolean;
   };
+  chainedTxs: string[];
+  inputsForEvaluation: Record<string, UTxO>;
   fee?: string;
   network: Network | number[][];
 };
@@ -61,6 +63,8 @@ export const emptyTxBuilderBody = (): MeshTxBuilderBody => ({
     strategy: "experimental",
     includeTxFees: true,
   },
+  chainedTxs: [],
+  inputsForEvaluation: {},
   network: "mainnet",
 });
 
@@ -76,7 +80,13 @@ export type ValidityRange = {
 // Transaction Metadata
 
 export type MetadatumMap = Map<Metadatum, Metadatum>;
-export type Metadatum = bigint | number | string | Uint8Array | MetadatumMap | Metadatum[];
+export type Metadatum =
+  | bigint
+  | number
+  | string
+  | Uint8Array
+  | MetadatumMap
+  | Metadatum[];
 export type TxMetadata = Map<bigint, Metadatum>;
 
 // to be used for serialization

--- a/packages/mesh-common/src/types/transaction-builder/txin.ts
+++ b/packages/mesh-common/src/types/transaction-builder/txin.ts
@@ -1,4 +1,5 @@
 import { Asset } from "../asset";
+import { UTxO } from "../utxo";
 import { DatumSource, Redeemer } from "./data";
 import { ScriptSource, SimpleScriptSourceInfo } from "./script";
 
@@ -36,4 +37,17 @@ export type ScriptTxIn = {
   type: "Script";
   txIn: TxInParameter;
   scriptTxIn: ScriptTxInParameter;
+};
+
+export const txInToUtxo = (txIn: TxInParameter): UTxO => {
+  return {
+    input: {
+      txHash: txIn.txHash,
+      outputIndex: txIn.txIndex,
+    },
+    output: {
+      address: txIn.address || "",
+      amount: txIn.amount || [],
+    },
+  };
 };

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -40,8 +40,8 @@
   },
   "dependencies": {
     "@meshsdk/common": "1.9.0-beta.1",
-    "@sidan-lab/sidan-csl-rs-browser": "0.9.18",
-    "@sidan-lab/sidan-csl-rs-nodejs": "0.9.18",
+    "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
+    "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
     "@types/base32-encoding": "^1.0.2",
     "base32-encoding": "^1.0.0",
     "bech32": "^2.0.0",

--- a/packages/mesh-core-csl/src/offline-providers/offline-evaluator.ts
+++ b/packages/mesh-core-csl/src/offline-providers/offline-evaluator.ts
@@ -127,7 +127,6 @@ export class OfflineEvaluator implements IEvaluator {
       }
     }
 
-    // TODO: filter only unresolved, go for fetcher
     const txHashesSet = new Set(
       inputsToResolve
         .filter((input) => {

--- a/packages/mesh-core-csl/src/offline-providers/offline-evaluator.ts
+++ b/packages/mesh-core-csl/src/offline-providers/offline-evaluator.ts
@@ -8,7 +8,11 @@ import {
   UTxO,
 } from "@meshsdk/common";
 
-import { evaluateTransaction, getTransactionInputs } from "../utils";
+import {
+  evaluateTransaction,
+  getTransactionInputs,
+  getTransactionOutputs,
+} from "../utils";
 
 /**
  * OfflineEvaluator implements the IEvaluator interface to provide offline evaluation of Plutus scripts.
@@ -103,10 +107,39 @@ export class OfflineEvaluator implements IEvaluator {
    *   - budget: Memory units and CPU steps required
    * @throws Error if any required UTXOs cannot be resolved or if script evaluation fails
    */
-  async evaluateTx(tx: string): Promise<Omit<Action, "data">[]> {
+  async evaluateTx(
+    tx: string,
+    additionalUtxos: UTxO[],
+    additionalTxs: string[],
+  ): Promise<Omit<Action, "data">[]> {
     const inputsToResolve = getTransactionInputs(tx);
-    const txHashesSet = new Set(inputsToResolve.map((input) => input.txHash));
-    const resolvedUTXOs: UTxO[] = [];
+
+    // Track which utxos is resolved
+    const foundUtxos = new Set<string>();
+
+    for (const utxo of additionalUtxos) {
+      foundUtxos.add(`${utxo.input.txHash}:${utxo.input.outputIndex}`);
+    }
+    for (const tx of additionalTxs) {
+      const outputs = getTransactionOutputs(tx);
+      for (const output of outputs) {
+        foundUtxos.add(`${output.input.txHash}:${output.input.outputIndex}`);
+      }
+    }
+
+    // TODO: filter only unresolved, go for fetcher
+    const txHashesSet = new Set(
+      inputsToResolve
+        .filter((input) => {
+          if (foundUtxos.has(`${input.txHash}:${input.outputIndex}`)) {
+            return false;
+          }
+          return true;
+        })
+        .map((input) => input.txHash),
+    );
+
+    const resolvedUtxos: UTxO[] = [];
     for (const txHash of txHashesSet) {
       const utxos = await this.fetcher.fetchUTxOs(txHash);
       for (const utxo of utxos) {
@@ -115,24 +148,24 @@ export class OfflineEvaluator implements IEvaluator {
             inputsToResolve.find(
               (input) =>
                 input.txHash === txHash &&
-                input.index === utxo.input.outputIndex,
+                input.outputIndex === utxo.input.outputIndex,
             )
           ) {
-            resolvedUTXOs.push(utxo);
+            additionalUtxos.push(utxo);
           }
       }
     }
     const missing = inputsToResolve.filter(
       (input) =>
-        !resolvedUTXOs.find(
+        !resolvedUtxos.find(
           (utxo) =>
             utxo.input.txHash === input.txHash &&
-            utxo.input.outputIndex === input.index,
+            utxo.input.outputIndex === input.outputIndex,
         ),
     );
     if (missing.length > 0) {
       const missingList = missing
-        .map((m) => `${m.txHash}:${m.index}`)
+        .map((m) => `${m.txHash}:${m.outputIndex}`)
         .join(", ");
       throw new Error(
         `Can't resolve these UTXOs to execute plutus scripts: ${missingList}`,
@@ -140,7 +173,8 @@ export class OfflineEvaluator implements IEvaluator {
     }
     return evaluateTransaction(
       tx,
-      resolvedUTXOs,
+      resolvedUtxos,
+      additionalTxs,
       this.network,
       this.slotConfig,
     );

--- a/packages/mesh-transaction/src/mesh-tx-builder/index.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/index.ts
@@ -151,7 +151,11 @@ export class MeshTxBuilder extends MeshTxBuilderCore {
     // Evaluating the transaction
     if (this.evaluator) {
       const txEvaluation = await this.evaluator
-        .evaluateTx(txHex)
+        .evaluateTx(
+          txHex,
+          Object.values(this.meshTxBuilderBody.inputsForEvaluation),
+          this.meshTxBuilderBody.chainedTxs,
+        )
         .catch((error) => {
           throw Error(`Tx evaluation failed: ${error} \n For txHex: ${txHex}`);
         });


### PR DESCRIPTION
## Summary

Add all-rounded support for offline eval, particularly user facing endpoints to supply additional txs and utxos.

## Affect components

> Please indicate which part of the Mesh Repo

- [X] `@meshsdk/core`
- [X] `@meshsdk/core-csl`
- [X] `@meshsdk/provider`
- [X] `@meshsdk/transaction`

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [X] New feature (non-breaking change which adds functionality)

## Additional Information

- Frontend documentation is not included in this PR. Issue would be created on docs upon merge.
- Currently the tx-chaining only works for `OfflineEvaluator`. Needa update provider implementation one by one on the `evaluateTx` to make it work for other provider services.
