### PR TITLE
fix: fixing offline eval fail parsing input to rust

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6041,14 +6041,8 @@
       "link": true
     },
     "node_modules/@meshsdk/hydra": {
-      "version": "1.9.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@meshsdk/hydra/-/hydra-1.9.0-beta.7.tgz",
-      "integrity": "sha512-LvCJsHzvTQEh63Fm9TG86sAg0q5iunJj5RREozLfVs3XK82RtBV2xK0p2+/2bQw2ugRiGJUAoRCp/AYRJQ+A4g==",
-      "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.7",
-        "@meshsdk/core-cst": "1.9.0-beta.7",
-        "axios": "^1.7.2"
-      }
+      "resolved": "packages/hydra",
+      "link": true
     },
     "node_modules/@meshsdk/provider": {
       "resolved": "packages/mesh-provider",
@@ -11655,6 +11649,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15619,6 +15614,7 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/html-escaper": {
@@ -17458,6 +17454,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -19096,6 +19093,7 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
       "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -19523,6 +19521,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -19535,6 +19534,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -25255,6 +25255,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -25265,12 +25266,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -25281,6 +25284,7 @@
       "version": "3.0.21",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
       "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/speed-limiter": {
@@ -27662,6 +27666,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -28638,6 +28643,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -28651,6 +28657,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -28899,9 +28906,25 @@
         "typescript": "^5.3.3"
       }
     },
+    "packages/hydra": {
+      "name": "@meshsdk/hydra",
+      "version": "1.9.0-beta.8",
+      "dependencies": {
+        "@meshsdk/common": "1.9.0-beta.8",
+        "@meshsdk/core-cst": "1.9.0-beta.8",
+        "axios": "^1.7.2"
+      },
+      "devDependencies": {
+        "@meshsdk/configs": "*",
+        "@swc/core": "^1.10.7",
+        "eslint": "^8.57.0",
+        "tsup": "^8.0.2",
+        "typescript": "^5.3.3"
+      }
+    },
     "packages/mesh-common": {
       "name": "@meshsdk/common",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "bech32": "^2.0.0",
@@ -28919,11 +28942,11 @@
     },
     "packages/mesh-contract": {
       "name": "@meshsdk/contract",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.7",
-        "@meshsdk/core": "1.9.0-beta.7"
+        "@meshsdk/common": "1.9.0-beta.8",
+        "@meshsdk/core": "1.9.0-beta.8"
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
@@ -28934,15 +28957,15 @@
     },
     "packages/mesh-core": {
       "name": "@meshsdk/core",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.7",
-        "@meshsdk/core-cst": "1.9.0-beta.7",
-        "@meshsdk/provider": "1.9.0-beta.7",
-        "@meshsdk/react": "1.9.0-beta.7",
-        "@meshsdk/transaction": "1.9.0-beta.7",
-        "@meshsdk/wallet": "1.9.0-beta.7"
+        "@meshsdk/common": "1.9.0-beta.8",
+        "@meshsdk/core-cst": "1.9.0-beta.8",
+        "@meshsdk/provider": "1.9.0-beta.8",
+        "@meshsdk/react": "1.9.0-beta.8",
+        "@meshsdk/transaction": "1.9.0-beta.8",
+        "@meshsdk/wallet": "1.9.0-beta.8"
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
@@ -28953,10 +28976,10 @@
     },
     "packages/mesh-core-csl": {
       "name": "@meshsdk/core-csl",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.7",
+        "@meshsdk/common": "1.9.0-beta.8",
         "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
         "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
         "@types/base32-encoding": "^1.0.2",
@@ -28966,7 +28989,7 @@
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
-        "@meshsdk/provider": "1.9.0-beta.7",
+        "@meshsdk/provider": "1.9.0-beta.8",
         "@types/json-bigint": "^1.0.4",
         "eslint": "^8.57.0",
         "ts-jest": "^29.1.4",
@@ -28976,7 +28999,7 @@
     },
     "packages/mesh-core-cst": {
       "name": "@meshsdk/core-cst",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@cardano-sdk/core": "^0.45.2",
@@ -28988,7 +29011,7 @@
         "@harmoniclabs/pair": "1.0.0",
         "@harmoniclabs/plutus-data": "1.2.4",
         "@harmoniclabs/uplc": "1.2.4",
-        "@meshsdk/common": "1.9.0-beta.7",
+        "@meshsdk/common": "1.9.0-beta.8",
         "@types/base32-encoding": "^1.0.2",
         "base32-encoding": "^1.0.0",
         "bech32": "^2.0.0",
@@ -29007,11 +29030,11 @@
     },
     "packages/mesh-provider": {
       "name": "@meshsdk/provider",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.7",
-        "@meshsdk/core-cst": "1.9.0-beta.7",
+        "@meshsdk/common": "1.9.0-beta.8",
+        "@meshsdk/core-cst": "1.9.0-beta.8",
         "@utxorpc/sdk": "0.6.2",
         "@utxorpc/spec": "0.10.1",
         "axios": "^1.7.2"
@@ -29026,13 +29049,13 @@
     },
     "packages/mesh-react": {
       "name": "@meshsdk/react",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@fabianbormann/cardano-peer-connect": "^1.2.18",
-        "@meshsdk/common": "1.9.0-beta.7",
-        "@meshsdk/transaction": "1.9.0-beta.7",
-        "@meshsdk/wallet": "1.9.0-beta.7",
+        "@meshsdk/common": "1.9.0-beta.8",
+        "@meshsdk/transaction": "1.9.0-beta.8",
+        "@meshsdk/wallet": "1.9.0-beta.8",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-icons": "^1.3.2",
@@ -29068,10 +29091,10 @@
     },
     "packages/mesh-svelte": {
       "name": "@meshsdk/svelte",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/core": "1.9.0-beta.7",
+        "@meshsdk/core": "1.9.0-beta.8",
         "bits-ui": "1.0.0-next.65"
       },
       "devDependencies": {
@@ -29097,11 +29120,11 @@
     },
     "packages/mesh-transaction": {
       "name": "@meshsdk/transaction",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.7",
-        "@meshsdk/core-cst": "1.9.0-beta.7",
+        "@meshsdk/common": "1.9.0-beta.8",
+        "@meshsdk/core-cst": "1.9.0-beta.8",
         "json-bigint": "^1.0.0"
       },
       "devDependencies": {
@@ -29114,12 +29137,12 @@
     },
     "packages/mesh-wallet": {
       "name": "@meshsdk/wallet",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.7",
-        "@meshsdk/core-cst": "1.9.0-beta.7",
-        "@meshsdk/transaction": "1.9.0-beta.7",
+        "@meshsdk/common": "1.9.0-beta.8",
+        "@meshsdk/core-cst": "1.9.0-beta.8",
+        "@meshsdk/transaction": "1.9.0-beta.8",
         "@simplewebauthn/browser": "^13.0.0"
       },
       "devDependencies": {
@@ -29132,7 +29155,7 @@
     },
     "scripts/mesh-cli": {
       "name": "meshjs",
-      "version": "1.9.0-beta.7",
+      "version": "1.9.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format:fix": "turbo run format --continue -- --write --cache --cache-location node_modules/.cache/.prettiercache",
     "lint": "turbo lint",
     "pack": "turbo pack",
-    "test": "turbo test",
+    "test": "turbo test -- --passWithNoTests",
     "sh:version": "sh scripts/bump-version.sh",
     "postinstall": "patch-package"
   },

--- a/packages/hydra/package.json
+++ b/packages/hydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/hydra",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Mesh Hydra package",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -27,8 +27,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.8",
-    "@meshsdk/core-cst": "1.9.0-beta.8",
+    "@meshsdk/common": "1.9.0-beta.9",
+    "@meshsdk/core-cst": "1.9.0-beta.9",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Contains constants, types and interfaces used across the SDK and different serialization libraries",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "List of open-source smart contracts, complete with documentation, live demos, and end-to-end source code. https://meshjs.dev/smart-contracts",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.8",
-    "@meshsdk/core": "1.9.0-beta.8"
+    "@meshsdk/common": "1.9.0-beta.9",
+    "@meshsdk/core": "1.9.0-beta.9"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Types and utilities functions between Mesh and cardano-serialization-lib",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@meshsdk/configs": "*",
-    "@meshsdk/provider": "1.9.0-beta.8",
+    "@meshsdk/provider": "1.9.0-beta.9",
     "@types/json-bigint": "^1.0.4",
     "eslint": "^8.57.0",
     "ts-jest": "^29.1.4",
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.8",
+    "@meshsdk/common": "1.9.0-beta.9",
     "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
     "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
     "@types/base32-encoding": "^1.0.2",

--- a/packages/mesh-core-csl/test/offline-providers/evaluator.test.ts
+++ b/packages/mesh-core-csl/test/offline-providers/evaluator.test.ts
@@ -132,6 +132,160 @@ describe("Offline Evaluator", () => {
     ]);
   });
 
+  it("should successfully evaluate correct tx 2", async () => {
+    const txHex =
+      "84a700d90102828258206eb7aa11907c377653e41dfd995dae8e6d468cfea0a645cdb4f4341fb963e8780282582078071c027011b376f0decf5e48f204d229be66c5711269101a98de1e7d30f43c010183a300581d70cc8ecbc5fab3ff89558bd3f6fe9dee68b448d7fe0f9a4b33cd38005301821a001e8480a1581cd1b3c84126916e1be2595d030194926546009f712a5432d0e7a2f717a14001028201d8185854d8799f581cfdeb4bf0e8c077114a4553f1e05395e9fb7114db177f02f7b65c8de4a240a1401a1dcd6500581c5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04ba144555344581a1dcd6500ff82581d7064a3f2ba1bb2084486728c9bb5f6c4b5c73598e2746f441593bda40f821a1daee080a1581c5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04ba144555344581a1dcd650082583900fdeb4bf0e8c077114a4553f1e05395e9fb7114db177f02f7b65c8de44e660f79ce4221d52a2dc249da925112b3ea46bcaba9ce48174fa358821b00000001a49f62e3a2581c5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04ba144555344581b00000016d0f508c0581cb80aa257a376c9ae7aa0c7a323db88d236e11e0a5ed5e10142da9ea0a14b000de140626561636f6e3301021a000c8a6d09a1581cd1b3c84126916e1be2595d030194926546009f712a5432d0e7a2f717a140010b582011bb34b7d88c308fd3ef46f2d8d149921b47aa74ea9f9d2e6f9452323c94d4b60dd90102818258207ab42fa758f9d5772a212cda5f866a3e1ad9948ce89f916feafeef73cbbabdb4000ed9010281581cfa5136e9e9ecbc9071da73eeb6c9a4ff73cbf436105cf8380d1c525ca207d901028158b158af010100333232323232232225333005323232323232330010013758601c601e601e601e601e601e601e601e601e60186ea8c038c030dd50039129998070008a50132533300d3371e6eb8c04000802c52889980180180098080009806180680118058009805801180480098031baa00114984d958dd7000ab9a5573caae7d5d0aba24c011e581cfa5136e9e9ecbc9071da73eeb6c9a4ff73cbf436105cf8380d1c525c004c010746332d6d696e74000105a182010082d87980821a006acfc01ab2d05e00f5f6";
+
+    const res = await evaluator.evaluateTx(
+      txHex,
+      [
+        {
+          input: {
+            outputIndex: 1,
+            txHash:
+              "78071c027011b376f0decf5e48f204d229be66c5711269101a98de1e7d30f43c",
+          },
+          output: {
+            address:
+              "addr_test1qr77kjlsarq8wy22g4flrcznjh5lkug5mvth7qhhkewgmezwvc8hnnjzy82j5twzf8dfy5gjk04yd09t488ys9605dvq4ymc4x",
+            amount: [
+              { unit: "lovelace", quantity: "50000000" },
+              {
+                unit: "5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04b55534458",
+                quantity: "65000000",
+              },
+            ],
+          },
+        },
+        {
+          input: {
+            outputIndex: 2,
+            txHash:
+              "6eb7aa11907c377653e41dfd995dae8e6d468cfea0a645cdb4f4341fb963e878",
+          },
+          output: {
+            address:
+              "addr_test1qr77kjlsarq8wy22g4flrcznjh5lkug5mvth7qhhkewgmezwvc8hnnjzy82j5twzf8dfy5gjk04yd09t488ys9605dvq4ymc4x",
+            amount: [
+              { unit: "lovelace", quantity: "7507698128" },
+              {
+                unit: "5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04b55534458",
+                quantity: "98430000000",
+              },
+              {
+                unit: "b80aa257a376c9ae7aa0c7a323db88d236e11e0a5ed5e10142da9ea0000de140626561636f6e33",
+                quantity: "1",
+              },
+            ],
+          },
+        },
+        {
+          input: {
+            txHash:
+              "6eb7aa11907c377653e41dfd995dae8e6d468cfea0a645cdb4f4341fb963e878",
+            outputIndex: 2,
+          },
+          output: {
+            address:
+              "addr_test1qr77kjlsarq8wy22g4flrcznjh5lkug5mvth7qhhkewgmezwvc8hnnjzy82j5twzf8dfy5gjk04yd09t488ys9605dvq4ymc4x",
+            amount: [
+              { unit: "lovelace", quantity: "7507698128" },
+              {
+                unit: "5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04b55534458",
+                quantity: "98430000000",
+              },
+              {
+                unit: "b80aa257a376c9ae7aa0c7a323db88d236e11e0a5ed5e10142da9ea0000de140626561636f6e33",
+                quantity: "1",
+              },
+            ],
+          },
+        },
+        {
+          input: {
+            txHash:
+              "6eb7aa11907c377653e41dfd995dae8e6d468cfea0a645cdb4f4341fb963e878",
+            outputIndex: 2,
+          },
+          output: {
+            address:
+              "addr_test1qr77kjlsarq8wy22g4flrcznjh5lkug5mvth7qhhkewgmezwvc8hnnjzy82j5twzf8dfy5gjk04yd09t488ys9605dvq4ymc4x",
+            amount: [
+              { unit: "lovelace", quantity: "7507698128" },
+              {
+                unit: "5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04b55534458",
+                quantity: "98430000000",
+              },
+              {
+                unit: "b80aa257a376c9ae7aa0c7a323db88d236e11e0a5ed5e10142da9ea0000de140626561636f6e33",
+                quantity: "1",
+              },
+            ],
+          },
+        },
+        {
+          input: {
+            txHash:
+              "78071c027011b376f0decf5e48f204d229be66c5711269101a98de1e7d30f43c",
+            outputIndex: 1,
+          },
+          output: {
+            address:
+              "addr_test1qr77kjlsarq8wy22g4flrcznjh5lkug5mvth7qhhkewgmezwvc8hnnjzy82j5twzf8dfy5gjk04yd09t488ys9605dvq4ymc4x",
+            amount: [
+              { unit: "lovelace", quantity: "50000000" },
+              {
+                unit: "5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04b55534458",
+                quantity: "65000000",
+              },
+            ],
+          },
+        },
+        {
+          input: {
+            txHash:
+              "78071c027011b376f0decf5e48f204d229be66c5711269101a98de1e7d30f43c",
+            outputIndex: 1,
+          },
+          output: {
+            address:
+              "addr_test1qr77kjlsarq8wy22g4flrcznjh5lkug5mvth7qhhkewgmezwvc8hnnjzy82j5twzf8dfy5gjk04yd09t488ys9605dvq4ymc4x",
+            amount: [
+              { unit: "lovelace", quantity: "50000000" },
+              {
+                unit: "5066154a102ee037390c5236f78db23239b49c5748d3d349f3ccf04b55534458",
+                quantity: "65000000",
+              },
+            ],
+          },
+        },
+        {
+          input: {
+            txHash:
+              "7ab42fa758f9d5772a212cda5f866a3e1ad9948ce89f916feafeef73cbbabdb4",
+            outputIndex: 0,
+          },
+          output: {
+            address:
+              "addr_test1qr77kjlsarq8wy22g4flrcznjh5lkug5mvth7qhhkewgmezwvc8hnnjzy82j5twzf8dfy5gjk04yd09t488ys9605dvq4ymc4x",
+            amount: [{ unit: "lovelace", quantity: "5000000" }],
+          },
+        },
+      ],
+      [],
+    );
+    expect(res).toStrictEqual([
+      {
+        index: 0,
+        tag: "MINT",
+        budget: {
+          mem: 15167,
+          steps: 4549992,
+        },
+      },
+    ]);
+  });
+
   it("should fail evaluating incorrect tx", async () => {
     fetcher.addUTxOs([
       {

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Types and utilities functions between Mesh and cardano-js-sdk",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -45,7 +45,7 @@
     "@harmoniclabs/pair": "1.0.0",
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
-    "@meshsdk/common": "1.9.0-beta.8",
+    "@meshsdk/common": "1.9.0-beta.9",
     "@types/base32-encoding": "^1.0.2",
     "base32-encoding": "^1.0.0",
     "bech32": "^2.0.0",

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Mesh SDK Core - https://meshjs.dev/",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,12 +33,12 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.8",
-    "@meshsdk/core-cst": "1.9.0-beta.8",
-    "@meshsdk/provider": "1.9.0-beta.8",
-    "@meshsdk/react": "1.9.0-beta.8",
-    "@meshsdk/transaction": "1.9.0-beta.8",
-    "@meshsdk/wallet": "1.9.0-beta.8"
+    "@meshsdk/common": "1.9.0-beta.9",
+    "@meshsdk/core-cst": "1.9.0-beta.9",
+    "@meshsdk/provider": "1.9.0-beta.9",
+    "@meshsdk/react": "1.9.0-beta.9",
+    "@meshsdk/transaction": "1.9.0-beta.9",
+    "@meshsdk/wallet": "1.9.0-beta.9"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Blockchain data providers - https://meshjs.dev/providers",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.8",
-    "@meshsdk/core-cst": "1.9.0-beta.8",
+    "@meshsdk/common": "1.9.0-beta.9",
+    "@meshsdk/core-cst": "1.9.0-beta.9",
     "@utxorpc/sdk": "0.6.2",
     "@utxorpc/spec": "0.10.1",
     "axios": "^1.7.2"

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "React component library - https://meshjs.dev/react",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@fabianbormann/cardano-peer-connect": "^1.2.18",
-    "@meshsdk/common": "1.9.0-beta.8",
-    "@meshsdk/transaction": "1.9.0-beta.8",
-    "@meshsdk/wallet": "1.9.0-beta.8",
+    "@meshsdk/common": "1.9.0-beta.9",
+    "@meshsdk/transaction": "1.9.0-beta.9",
+    "@meshsdk/wallet": "1.9.0-beta.9",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.2",

--- a/packages/mesh-svelte/package.json
+++ b/packages/mesh-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/svelte",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Svelte component library - https://meshjs.dev/svelte",
   "type": "module",
   "exports": {
@@ -26,7 +26,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "@meshsdk/core": "1.9.0-beta.8",
+    "@meshsdk/core": "1.9.0-beta.9",
     "bits-ui": "1.0.0-next.65"
   },
   "devDependencies": {

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Transactions - https://meshjs.dev/apis/transaction",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.8",
-    "@meshsdk/core-cst": "1.9.0-beta.8",
+    "@meshsdk/common": "1.9.0-beta.9",
+    "@meshsdk/core-cst": "1.9.0-beta.9",
     "json-bigint": "^1.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-transaction/src/mesh-tx-builder/index.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/index.ts
@@ -256,6 +256,9 @@ export class MeshTxBuilder extends MeshTxBuilderCore {
             Object.values(this.meshTxBuilderBody.inputsForEvaluation) as UTxO[]
           ).concat(
             this.meshTxBuilderBody.inputs.map((val) => txInToUtxo(val.txIn)),
+            this.meshTxBuilderBody.collaterals.map((val) =>
+              txInToUtxo(val.txIn),
+            ),
           ),
           this.meshTxBuilderBody.chainedTxs,
         )

--- a/packages/mesh-transaction/src/mesh-tx-builder/tx-builder-core.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/tx-builder-core.ts
@@ -1520,9 +1520,6 @@ export class MeshTxBuilderCore {
     const currentUtxo = this.meshTxBuilderBody.inputsForEvaluation[utxoId];
 
     if (currentUtxo) {
-      const { address, amount, dataHash, plutusData, scriptRef, scriptHash } =
-        input.output;
-
       const {
         dataHash: currentDataHash,
         plutusData: currentPlutusData,
@@ -1530,17 +1527,12 @@ export class MeshTxBuilderCore {
         scriptHash: currentScriptHash,
       } = currentUtxo.output;
 
-      const updatedUtxo: UTxO = {
-        ...input,
-        output: {
-          address,
-          amount,
-          dataHash: dataHash ?? currentDataHash,
-          plutusData: plutusData ?? currentPlutusData,
-          scriptRef: scriptRef ?? currentScriptRef,
-          scriptHash: scriptHash ?? currentScriptHash,
-        },
-      };
+      const updatedUtxo: UTxO = { ...currentUtxo };
+      if (currentDataHash) updatedUtxo.output.dataHash = currentDataHash;
+      if (currentPlutusData) updatedUtxo.output.plutusData = currentPlutusData;
+      if (currentScriptRef) updatedUtxo.output.scriptRef = currentScriptRef;
+      if (currentScriptHash) updatedUtxo.output.scriptHash = currentScriptHash;
+
       this.meshTxBuilderBody.inputsForEvaluation[utxoId] = updatedUtxo;
     } else {
       this.meshTxBuilderBody.inputsForEvaluation[utxoId] = input;

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "description": "Wallets - https://meshjs.dev/apis/wallets",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.8",
-    "@meshsdk/core-cst": "1.9.0-beta.8",
-    "@meshsdk/transaction": "1.9.0-beta.8",
+    "@meshsdk/common": "1.9.0-beta.9",
+    "@meshsdk/core-cst": "1.9.0-beta.9",
+    "@meshsdk/transaction": "1.9.0-beta.9",
     "@simplewebauthn/browser": "^13.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your dApps on Cardano using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.9.0-beta.8",
+  "version": "1.9.0-beta.9",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Fixing offline evaluator fail to provide extra utxo to wasm due to panic on empty string for plutus data. It changes to retaining as null rather than empty string to pass the rust type casting.

## Affect components

- [X] `@meshsdk/transaction`

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [X] Bug fix (non-breaking change which fixes an issue)
