### PR TITLE
De-duplicate reference inputs

### DIFF
--- a/packages/mesh-core-cst/src/serializer/index.ts
+++ b/packages/mesh-core-cst/src/serializer/index.ts
@@ -1506,12 +1506,16 @@ class CardanoSDKSerializerCore {
 
     let referenceInputsList = [...referenceInputs.values()];
 
-    referenceInputsList.push(
-      new TransactionInput(
-        TransactionId(scriptSource.txHash),
-        BigInt(scriptSource.txIndex),
-      ),
+    // Create new input
+    const newInput = new TransactionInput(
+      TransactionId(scriptSource.txHash),
+      BigInt(scriptSource.txIndex)
     );
+    if (referenceInputsList.some(input =>
+      input.transactionId() === newInput.transactionId() &&
+      input.index() === newInput.index()
+    )) return; // Do not insert duplicate inputs
+    referenceInputsList.push(newInput);
 
     referenceInputs.setValues(referenceInputsList);
 


### PR DESCRIPTION
## Summary

When minting multiple assets with the same policyId from a reference script, the reference input is duplicated. This results in unnecessary duplication in the transaction, potentially increasing fees.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [x] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

> Please ensure that your pull request meets the following criteria:

- [ ] My code is appropriately commented and includes relevant documentation, if necessary
- [ ] I have added tests to cover my changes, if necessary
- [ ] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)
