### PR TITLE
Fix/vote withdrawal plutus script tag

### DIFF
--- a/packages/hydra/package.json
+++ b/packages/hydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/hydra",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Mesh Hydra package",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -27,8 +27,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.12",
-    "@meshsdk/core-cst": "1.9.0-beta.12",
+    "@meshsdk/common": "1.9.0-beta.13",
+    "@meshsdk/core-cst": "1.9.0-beta.13",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Contains constants, types and interfaces used across the SDK and different serialization libraries",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "List of open-source smart contracts, complete with documentation, live demos, and end-to-end source code. https://meshjs.dev/smart-contracts",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.12",
-    "@meshsdk/core": "1.9.0-beta.12"
+    "@meshsdk/common": "1.9.0-beta.13",
+    "@meshsdk/core": "1.9.0-beta.13"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Types and utilities functions between Mesh and cardano-serialization-lib",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@meshsdk/configs": "*",
-    "@meshsdk/provider": "1.9.0-beta.12",
+    "@meshsdk/provider": "1.9.0-beta.13",
     "@types/json-bigint": "^1.0.4",
     "eslint": "^8.57.0",
     "ts-jest": "^29.1.4",
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.12",
+    "@meshsdk/common": "1.9.0-beta.13",
     "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
     "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
     "@types/base32-encoding": "^1.0.2",

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Types and utilities functions between Mesh and cardano-js-sdk",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -45,7 +45,7 @@
     "@harmoniclabs/pair": "1.0.0",
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
-    "@meshsdk/common": "1.9.0-beta.12",
+    "@meshsdk/common": "1.9.0-beta.13",
     "@types/base32-encoding": "^1.0.2",
     "base32-encoding": "^1.0.0",
     "bech32": "^2.0.0",

--- a/packages/mesh-core-cst/src/serializer/index.ts
+++ b/packages/mesh-core-cst/src/serializer/index.ts
@@ -1464,6 +1464,9 @@ class CardanoSDKSerializerCore {
           "Insufficient funds to create change output with tokens",
         );
       } else {
+        if (remainingValue.coin() < fee) {
+          throw new Error("Insufficient funds to pay fee");
+        }
         fee = remainingValue.coin();
         currentOutputs.pop();
       }

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Mesh SDK Core - https://meshjs.dev/",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,12 +33,12 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.12",
-    "@meshsdk/core-cst": "1.9.0-beta.12",
-    "@meshsdk/provider": "1.9.0-beta.12",
-    "@meshsdk/react": "1.9.0-beta.12",
-    "@meshsdk/transaction": "1.9.0-beta.12",
-    "@meshsdk/wallet": "1.9.0-beta.12"
+    "@meshsdk/common": "1.9.0-beta.13",
+    "@meshsdk/core-cst": "1.9.0-beta.13",
+    "@meshsdk/provider": "1.9.0-beta.13",
+    "@meshsdk/react": "1.9.0-beta.13",
+    "@meshsdk/transaction": "1.9.0-beta.13",
+    "@meshsdk/wallet": "1.9.0-beta.13"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Blockchain data providers - https://meshjs.dev/providers",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.12",
-    "@meshsdk/core-cst": "1.9.0-beta.12",
+    "@meshsdk/common": "1.9.0-beta.13",
+    "@meshsdk/core-cst": "1.9.0-beta.13",
     "@utxorpc/sdk": "0.6.2",
     "@utxorpc/spec": "0.10.1",
     "axios": "^1.7.2"

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "React component library - https://meshjs.dev/react",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@fabianbormann/cardano-peer-connect": "^1.2.18",
-    "@meshsdk/common": "1.9.0-beta.12",
-    "@meshsdk/transaction": "1.9.0-beta.12",
-    "@meshsdk/wallet": "1.9.0-beta.12",
+    "@meshsdk/common": "1.9.0-beta.13",
+    "@meshsdk/transaction": "1.9.0-beta.13",
+    "@meshsdk/wallet": "1.9.0-beta.13",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.2",

--- a/packages/mesh-svelte/package.json
+++ b/packages/mesh-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/svelte",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Svelte component library - https://meshjs.dev/svelte",
   "type": "module",
   "exports": {
@@ -26,7 +26,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "@meshsdk/core": "1.9.0-beta.12",
+    "@meshsdk/core": "1.9.0-beta.13",
     "bits-ui": "1.0.0-next.65"
   },
   "devDependencies": {

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Transactions - https://meshjs.dev/apis/transaction",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.12",
-    "@meshsdk/core-cst": "1.9.0-beta.12",
+    "@meshsdk/common": "1.9.0-beta.13",
+    "@meshsdk/core-cst": "1.9.0-beta.13",
     "json-bigint": "^1.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-transaction/src/mesh-tx-builder/tx-builder-core.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/tx-builder-core.ts
@@ -826,6 +826,7 @@ export class MeshTxBuilderCore {
         coin: coin,
       };
       this.withdrawalItem = withdrawal;
+      this.addingPlutusWithdrawal = false;
       return this;
     }
 
@@ -992,6 +993,7 @@ export class MeshTxBuilderCore {
         },
       };
       this.voteItem = vote;
+      this.addingPlutusVote = false;
     } else {
       const vote: Vote = {
         type: "BasicVote",

--- a/packages/mesh-transaction/test/mesh-tx-builder/balance.test.ts
+++ b/packages/mesh-transaction/test/mesh-tx-builder/balance.test.ts
@@ -90,4 +90,35 @@ describe("MeshTxBuilder", () => {
     );
     expect(cardanoTx.body().outputs().length).toEqual(2);
   });
+
+  it("Transaction without enough lovelaces for fees should throw error", async () => {
+    await expect(
+      txBuilder
+        .txIn(
+          txHash("tx0"),
+          0,
+          [
+            {
+              unit: "lovelace",
+              quantity: "1000000",
+            },
+          ],
+          "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+          0,
+        )
+        .txOut(
+          "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+          [
+            {
+              unit: "lovelace",
+              quantity: "900000",
+            },
+          ],
+        )
+        .changeAddress(
+          "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+        )
+        .complete(),
+    ).rejects.toThrow("Insufficient funds to pay fee");
+  });
 });

--- a/packages/mesh-transaction/test/mesh-tx-builder/script-tx.test.ts
+++ b/packages/mesh-transaction/test/mesh-tx-builder/script-tx.test.ts
@@ -5,6 +5,7 @@ import {
   MeshTxBuilder,
   OfflineFetcher,
   resolveScriptHash,
+  serializeNativeScript,
   serializePlutusScript,
   serializeRewardAddress,
   UTxO,
@@ -12,6 +13,7 @@ import {
 import { CSLSerializer, OfflineEvaluator } from "@meshsdk/core-csl";
 import {
   blake2b,
+  resolveNativeScriptHash,
   resolveScriptHashDRepId,
   resolveScriptRef,
 } from "@meshsdk/core-cst";
@@ -571,6 +573,154 @@ describe("MeshTxBuilder - Script Transactions", () => {
       ),
     ).toEqual([
       { budget: { mem: 2001, steps: 380149 }, index: 0, tag: "VOTE" },
+    ]);
+  });
+
+  it("should be able to vote with plutus script and native script", async () => {
+    const txHex = await txBuilder
+      .votePlutusScriptV3()
+      .vote(
+        { type: "DRep", drepId: resolveScriptHashDRepId(alwaysSucceedHash) },
+        { txHash: txHash("tx100"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteTxInReference(txHash("tx3"), 0)
+      .voteRedeemerValue("")
+      .vote(
+        {
+          type: "DRep",
+          drepId: resolveScriptHashDRepId(
+            resolveNativeScriptHash({ type: "all", scripts: [] }),
+          ),
+        },
+        { txHash: txHash("tx100"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteScript(
+        serializeNativeScript({ type: "all", scripts: [] }).scriptCbor!,
+      )
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+    const txHex2 = await txBuilder2
+      .votePlutusScriptV3()
+      .vote(
+        { type: "DRep", drepId: resolveScriptHashDRepId(alwaysSucceedHash) },
+        { txHash: txHash("tx100"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteTxInReference(txHash("tx3"), 0)
+      .voteRedeemerValue("")
+      .vote(
+        {
+          type: "DRep",
+          drepId: resolveScriptHashDRepId(
+            resolveNativeScriptHash({ type: "all", scripts: [] }),
+          ),
+        },
+        { txHash: txHash("tx100"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteScript(
+        serializeNativeScript({ type: "all", scripts: [] }).scriptCbor!,
+      )
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+    expect(
+      await offlineEvaluator.evaluateTx(
+        txHex,
+        Object.values(
+          txBuilder.meshTxBuilderBody.inputsForEvaluation,
+        ) as UTxO[],
+        txBuilder.meshTxBuilderBody.chainedTxs,
+      ),
+    ).toEqual([
+      { budget: { mem: 2001, steps: 380149 }, index: 0, tag: "VOTE" },
+    ]);
+    expect(
+      await offlineEvaluator.evaluateTx(
+        txHex2,
+        Object.values(
+          txBuilder.meshTxBuilderBody.inputsForEvaluation,
+        ) as UTxO[],
+        txBuilder.meshTxBuilderBody.chainedTxs,
+      ),
+    ).toEqual([
+      { budget: { mem: 2001, steps: 380149 }, index: 0, tag: "VOTE" },
+    ]);
+  });
+
+  it("should be able to withdraw with plutus script and native script", async () => {
+    const txHex = await txBuilder
+      .withdrawalPlutusScriptV3()
+      .withdrawal(serializeRewardAddress(alwaysSucceedHash, true), "0")
+      .withdrawalScript(alwaysSucceedCbor)
+      .withdrawalRedeemerValue("")
+      .withdrawal(
+        serializeRewardAddress(
+          resolveNativeScriptHash({ type: "all", scripts: [] }),
+          true,
+        ),
+        "0",
+      )
+      .withdrawalScript(
+        serializeNativeScript({ type: "all", scripts: [] }).scriptCbor!,
+      )
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+    const txHex2 = await txBuilder2
+      .withdrawalPlutusScriptV3()
+      .withdrawal(serializeRewardAddress(alwaysSucceedHash, true), "0")
+      .withdrawalScript(alwaysSucceedCbor)
+      .withdrawalRedeemerValue("")
+      .withdrawal(
+        serializeRewardAddress(
+          resolveNativeScriptHash({ type: "all", scripts: [] }),
+          true,
+        ),
+        "0",
+      )
+      .withdrawalScript(
+        serializeNativeScript({ type: "all", scripts: [] }).scriptCbor!,
+      )
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+    expect(
+      await offlineEvaluator.evaluateTx(
+        txHex,
+        Object.values(
+          txBuilder.meshTxBuilderBody.inputsForEvaluation,
+        ) as UTxO[],
+        txBuilder.meshTxBuilderBody.chainedTxs,
+      ),
+    ).toEqual([
+      { budget: { mem: 2001, steps: 380149 }, index: 0, tag: "REWARD" },
+    ]);
+    expect(
+      await offlineEvaluator.evaluateTx(
+        txHex2,
+        Object.values(
+          txBuilder.meshTxBuilderBody.inputsForEvaluation,
+        ) as UTxO[],
+        txBuilder.meshTxBuilderBody.chainedTxs,
+      ),
+    ).toEqual([
+      { budget: { mem: 2001, steps: 380149 }, index: 0, tag: "REWARD" },
     ]);
   });
 });

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "description": "Wallets - https://meshjs.dev/apis/wallets",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.12",
-    "@meshsdk/core-cst": "1.9.0-beta.12",
-    "@meshsdk/transaction": "1.9.0-beta.12",
+    "@meshsdk/common": "1.9.0-beta.13",
+    "@meshsdk/core-cst": "1.9.0-beta.13",
+    "@meshsdk/transaction": "1.9.0-beta.13",
     "@simplewebauthn/browser": "^13.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your dApps on Cardano using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.9.0-beta.12",
+  "version": "1.9.0-beta.13",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Vote and withdrawal didn't reset the `addingPlutus` tag after completion, which meant there would be bug if adding a non script withdrawal/vote after adding script one.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [x] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [x] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

