### PR TITLE
Fix/duplicate ref inputs

### DIFF
--- a/packages/mesh-core-cst/src/utils/certificate.ts
+++ b/packages/mesh-core-cst/src/utils/certificate.ts
@@ -127,7 +127,9 @@ export const toCardanoCert = (cert: CertificateType): CardanoCert => {
       return CardanoCert.newStakeDelegation(
         new Serialization.StakeDelegation(
           rewardAddress.getPaymentCredential(),
-          Ed25519KeyHashHex(cert.poolId),
+          cert.poolId.startsWith("pool1")
+            ? Cardano.PoolId.toKeyHash(Cardano.PoolId(cert.poolId))
+            : Ed25519KeyHashHex(cert.poolId),
         ),
       );
     }
@@ -151,7 +153,9 @@ export const toCardanoCert = (cert: CertificateType): CardanoCert => {
     case "RetirePool": {
       return CardanoCert.newPoolRetirement(
         new Serialization.PoolRetirement(
-          Ed25519KeyHashHex(cert.poolId),
+          cert.poolId.startsWith("pool1")
+            ? Cardano.PoolId.toKeyHash(Cardano.PoolId(cert.poolId))
+            : Ed25519KeyHashHex(cert.poolId),
           Cardano.EpochNo(cert.epoch),
         ),
       );
@@ -399,7 +403,7 @@ export const toCardanoCert = (cert: CertificateType): CardanoCert => {
           ),
         );
       } else {
-        throw new Error("DRepId must be a Credential")
+        throw new Error("DRepId must be a Credential");
       }
     }
     case "DRepDeregistration": {
@@ -412,7 +416,7 @@ export const toCardanoCert = (cert: CertificateType): CardanoCert => {
           ),
         );
       } else {
-        throw new Error("DRepId must be a Credential")
+        throw new Error("DRepId must be a Credential");
       }
     }
     case "DRepUpdate": {
@@ -430,7 +434,7 @@ export const toCardanoCert = (cert: CertificateType): CardanoCert => {
           new Serialization.UpdateDelegateRepresentative(coreDRep, anchor),
         );
       } else {
-        throw new Error("DRepId must be a Credential")
+        throw new Error("DRepId must be a Credential");
       }
     }
   }

--- a/packages/mesh-transaction/src/mesh-tx-builder/index.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/index.ts
@@ -328,6 +328,7 @@ export class MeshTxBuilder extends MeshTxBuilderCore {
       this.queueAllLastItem();
     }
     this.removeDuplicateInputs();
+    this.removeDuplicateRefInputs();
 
     // We can set scriptSize of collaterals as 0, because the ledger ignores this for fee calculations
     for (let collateral of this.meshTxBuilderBody.collaterals) {

--- a/packages/mesh-transaction/src/mesh-tx-builder/tx-builder-core.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/tx-builder-core.ts
@@ -1861,6 +1861,25 @@ export class MeshTxBuilderCore {
     this.meshTxBuilderBody.inputs = addedInputs;
   };
 
+  removeDuplicateRefInputs = () => {
+    const { referenceInputs } = this.meshTxBuilderBody;
+    const getTxInId = (txIn: RefTxIn): string =>
+      `${txIn.txHash}#${txIn.txIndex}`;
+    const currentTxInIds: string[] = [];
+    const addedInputs: RefTxIn[] = [];
+    for (let i = 0; i < referenceInputs.length; i += 1) {
+      const currentInput = referenceInputs[i]!;
+      const currentTxInId = getTxInId(currentInput);
+      if (currentTxInIds.includes(currentTxInId)) {
+        referenceInputs.splice(i, 1);
+        i -= 1;
+      } else {
+        addedInputs.push(currentInput);
+      }
+    }
+    this.meshTxBuilderBody.referenceInputs = addedInputs;
+  };
+
   emptyTxBuilderBody = () => {
     this.meshTxBuilderBody = emptyTxBuilderBody();
     return emptyTxBuilderBody;

--- a/packages/mesh-transaction/test/mesh-tx-builder/duplicate-ref-input.test.ts
+++ b/packages/mesh-transaction/test/mesh-tx-builder/duplicate-ref-input.test.ts
@@ -1,0 +1,355 @@
+import {
+  applyCborEncoding,
+  DRep,
+  MeshTxBuilder,
+  OfflineFetcher,
+  resolveScriptHash,
+  serializeNativeScript,
+  serializePlutusScript,
+  serializeRewardAddress,
+} from "@meshsdk/core";
+import { CSLSerializer, OfflineEvaluator } from "@meshsdk/core-csl";
+import {
+  blake2b,
+  resolveNativeScriptHash,
+  resolveScriptHashDRepId,
+  resolveScriptRef,
+  Serialization,
+} from "@meshsdk/core-cst";
+
+describe("MeshTxBuilder - Duplicate Ref Input", () => {
+  const alwaysSucceedCbor = applyCborEncoding(
+    "58340101002332259800a518a4d153300249011856616c696461746f722072657475726e65642066616c736500136564004ae715cd01",
+  );
+
+  const alwaysSucceedHash = resolveScriptHash(alwaysSucceedCbor, "V3");
+
+  const offlineFetcher = new OfflineFetcher();
+  const offlineEvaluator = new OfflineEvaluator(offlineFetcher, "preprod");
+
+  const txHash = (tx: string) => {
+    return blake2b(32).update(Buffer.from(tx, "utf-8")).digest("hex");
+  };
+
+  offlineFetcher.addUTxOs([
+    {
+      input: {
+        txHash: txHash("tx1"),
+        outputIndex: 0,
+      },
+      output: {
+        address:
+          "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+        amount: [
+          {
+            unit: "lovelace",
+            quantity: "100000000",
+          },
+        ],
+      },
+    },
+    {
+      input: {
+        txHash: txHash("tx2"),
+        outputIndex: 0,
+      },
+      output: {
+        address: serializePlutusScript({
+          code: alwaysSucceedCbor,
+          version: "V3",
+        }).address,
+        amount: [
+          {
+            unit: "lovelace",
+            quantity: "100000000",
+          },
+        ],
+      },
+    },
+    {
+      input: {
+        txHash: txHash("tx3"),
+        outputIndex: 0,
+      },
+      output: {
+        address: serializePlutusScript({
+          code: alwaysSucceedCbor,
+          version: "V3",
+        }).address,
+        amount: [
+          {
+            unit: "lovelace",
+            quantity: "100000000",
+          },
+        ],
+        scriptHash: alwaysSucceedHash,
+        scriptRef: resolveScriptRef({ code: alwaysSucceedCbor, version: "V3" }),
+      },
+    },
+  ]);
+
+  const txBuilder = new MeshTxBuilder({
+    serializer: new CSLSerializer(),
+    fetcher: offlineFetcher,
+  });
+
+  const txBuilder2 = new MeshTxBuilder({
+    fetcher: offlineFetcher,
+  });
+
+  beforeEach(() => {
+    txBuilder.reset();
+    txBuilder2.reset();
+  });
+
+  it("Spending from the same script address multiple times should only have one script ref", async () => {
+    const txHex = await txBuilder
+      .spendingPlutusScriptV3()
+      .txIn(txHash("tx1"), 0)
+      .txInInlineDatumPresent()
+      .txInRedeemerValue("")
+      .spendingTxInReference(txHash("tx3"), 0)
+      .spendingPlutusScriptV3()
+      .txIn(txHash("tx2"), 0)
+      .txInInlineDatumPresent()
+      .txInRedeemerValue("")
+      .spendingTxInReference(txHash("tx3"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const txHex2 = await txBuilder2
+      .spendingPlutusScriptV3()
+      .txIn(txHash("tx2"), 0)
+      .txInInlineDatumPresent()
+      .txInRedeemerValue("")
+      .spendingTxInReference(txHash("tx3"), 0)
+      .spendingPlutusScriptV3()
+      .txIn(txHash("tx2"), 0)
+      .txInInlineDatumPresent()
+      .txInRedeemerValue("")
+      .spendingTxInReference(txHash("tx3"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const cardanoTx = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex),
+    );
+    const cardanoTx2 = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex2),
+    );
+    expect(cardanoTx.body().referenceInputs()!.size()).toEqual(1);
+    expect(cardanoTx2.body().referenceInputs()!.size()).toEqual(1);
+  });
+
+  it("Minting multiple tokens with the same policy should only have one script ref", async () => {
+    const txHex = await txBuilder
+      .mintPlutusScriptV3()
+      .mint("1", alwaysSucceedHash, "60")
+      .mintRedeemerValue("")
+      .mintTxInReference(txHash("tx3"), 0)
+      .mintPlutusScriptV3()
+      .mint("1", alwaysSucceedHash, "61")
+      .mintRedeemerValue("")
+      .mintTxInReference(txHash("tx3"), 0)
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const txHex2 = await txBuilder2
+      .mintPlutusScriptV3()
+      .mint("1", alwaysSucceedHash, "60")
+      .mintRedeemerValue("")
+      .mintTxInReference(txHash("tx3"), 0)
+      .mintPlutusScriptV3()
+      .mint("1", alwaysSucceedHash, "61")
+      .mintRedeemerValue("")
+      .mintTxInReference(txHash("tx3"), 0)
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const cardanoTx = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex),
+    );
+    const cardanoTx2 = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex2),
+    );
+    expect(cardanoTx.body().referenceInputs()!.size()).toEqual(1);
+    expect(cardanoTx2.body().referenceInputs()!.size()).toEqual(1);
+  });
+
+  it("Withdrawing multiple times with the same script should only have one script ref", async () => {
+    const txHex = await txBuilder
+      .withdrawalPlutusScriptV3()
+      .withdrawal(serializeRewardAddress(alwaysSucceedHash, true), "0")
+      .withdrawalScript(alwaysSucceedCbor)
+      .withdrawalRedeemerValue("")
+      .withdrawalTxInReference(txHash("tx3"), 0)
+      .withdrawalPlutusScriptV3()
+      .withdrawal(serializeRewardAddress(alwaysSucceedHash, true), "0")
+      .withdrawalScript(alwaysSucceedCbor)
+      .withdrawalRedeemerValue("")
+      .withdrawalTxInReference(txHash("tx3"), 0)
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const txHex2 = await txBuilder2
+      .withdrawalPlutusScriptV3()
+      .withdrawal(serializeRewardAddress(alwaysSucceedHash, true), "0")
+      .withdrawalScript(alwaysSucceedCbor)
+      .withdrawalRedeemerValue("")
+      .withdrawalTxInReference(txHash("tx3"), 0)
+      .withdrawalPlutusScriptV3()
+      .withdrawal(serializeRewardAddress(alwaysSucceedHash, true), "0")
+      .withdrawalScript(alwaysSucceedCbor)
+      .withdrawalRedeemerValue("")
+      .withdrawalTxInReference(txHash("tx3"), 0)
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const cardanoTx = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex),
+    );
+    const cardanoTx2 = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex2),
+    );
+    expect(cardanoTx.body().referenceInputs()!.size()).toEqual(1);
+    expect(cardanoTx2.body().referenceInputs()!.size()).toEqual(1);
+    // This isn't actually possible and should be deduplicated, so there should only be a single withdrawal
+    expect(cardanoTx.body().withdrawals()!.size).toEqual(1);
+    expect(cardanoTx2.body().withdrawals()!.size).toEqual(1);
+  });
+
+  it("Multiple certificates with the same script should only have one script ref", async () => {
+    const drep: DRep = {
+      alwaysAbstain: null,
+    };
+
+    const txHex = await txBuilder
+      .voteDelegationCertificate(
+        drep,
+        serializeRewardAddress(alwaysSucceedHash, true),
+      )
+      .certificateTxInReference(txHash("tx3"), 0, undefined, undefined, "V3")
+      .certificateRedeemerValue("")
+      .delegateStakeCertificate(
+        serializeRewardAddress(alwaysSucceedHash, true),
+        "624fcb718d9facc7dcc8daa3c5cad6753886ddc968cc4a6bea5e9cc3",
+      )
+      .certificateTxInReference(txHash("tx3"), 0, undefined, undefined, "V3")
+      .certificateRedeemerValue("")
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const txHex2 = await txBuilder2
+      .voteDelegationCertificate(
+        drep,
+        serializeRewardAddress(alwaysSucceedHash, true),
+      )
+      .certificateTxInReference(txHash("tx3"), 0, undefined, undefined, "V3")
+      .certificateRedeemerValue("")
+      .delegateStakeCertificate(
+        serializeRewardAddress(alwaysSucceedHash, true),
+        "pool1vf8ukuvdn7kv0hxgm23utjkkw5ugdhwfdrxy56l2t6wvxezspyu",
+      )
+      .certificateTxInReference(txHash("tx3"), 0, undefined, undefined, "V3")
+      .certificateRedeemerValue("")
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const cardanoTx = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex),
+    );
+    const cardanoTx2 = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex2),
+    );
+    expect(cardanoTx.body().referenceInputs()!.size()).toEqual(1);
+    expect(cardanoTx2.body().referenceInputs()!.size()).toEqual(1);
+  });
+
+  it("Multiple votes with the same script should only have one script ref", async () => {
+    const txHex = await txBuilder
+      .votePlutusScriptV3()
+      .vote(
+        { type: "DRep", drepId: resolveScriptHashDRepId(alwaysSucceedHash) },
+        { txHash: txHash("tx100"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteTxInReference(txHash("tx3"), 0)
+      .voteRedeemerValue("")
+      .votePlutusScriptV3()
+      .vote(
+        { type: "DRep", drepId: resolveScriptHashDRepId(alwaysSucceedHash) },
+        { txHash: txHash("tx100"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteTxInReference(txHash("tx3"), 0)
+      .voteRedeemerValue("")
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+    const txHex2 = await txBuilder2
+      .votePlutusScriptV3()
+      .vote(
+        { type: "DRep", drepId: resolveScriptHashDRepId(alwaysSucceedHash) },
+        { txHash: txHash("tx100"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteTxInReference(txHash("tx3"), 0)
+      .voteRedeemerValue("")
+      .votePlutusScriptV3()
+      .vote(
+        { type: "DRep", drepId: resolveScriptHashDRepId(alwaysSucceedHash) },
+        { txHash: txHash("tx101"), txIndex: 0 },
+        { voteKind: "Yes" },
+      )
+      .voteTxInReference(txHash("tx3"), 0)
+      .voteRedeemerValue("")
+      .txIn(txHash("tx1"), 0)
+      .txInCollateral(txHash("tx1"), 0)
+      .changeAddress(
+        "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
+      )
+      .complete();
+
+    const cardanoTx = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex),
+    );
+    const cardanoTx2 = Serialization.Transaction.fromCbor(
+      Serialization.TxCBOR(txHex2),
+    );
+    expect(cardanoTx.body().referenceInputs()!.size()).toEqual(1);
+    expect(cardanoTx2.body().referenceInputs()!.size()).toEqual(1);
+  });
+});

--- a/packages/mesh-transaction/test/mesh-tx-builder/duplicate-ref-input.test.ts
+++ b/packages/mesh-transaction/test/mesh-tx-builder/duplicate-ref-input.test.ts
@@ -4,14 +4,12 @@ import {
   MeshTxBuilder,
   OfflineFetcher,
   resolveScriptHash,
-  serializeNativeScript,
   serializePlutusScript,
   serializeRewardAddress,
 } from "@meshsdk/core";
-import { CSLSerializer, OfflineEvaluator } from "@meshsdk/core-csl";
+import { OfflineEvaluator } from "@meshsdk/core-csl";
 import {
   blake2b,
-  resolveNativeScriptHash,
   resolveScriptHashDRepId,
   resolveScriptRef,
   Serialization,
@@ -89,8 +87,7 @@ describe("MeshTxBuilder - Duplicate Ref Input", () => {
   ]);
 
   const txBuilder = new MeshTxBuilder({
-    serializer: new CSLSerializer(),
-    fetcher: offlineFetcher,
+    evaluator: offlineEvaluator,
   });
 
   const txBuilder2 = new MeshTxBuilder({

--- a/packages/mesh-transaction/test/mesh-tx-builder/duplicate-ref-input.test.ts
+++ b/packages/mesh-transaction/test/mesh-tx-builder/duplicate-ref-input.test.ts
@@ -87,7 +87,7 @@ describe("MeshTxBuilder - Duplicate Ref Input", () => {
   ]);
 
   const txBuilder = new MeshTxBuilder({
-    evaluator: offlineEvaluator,
+    fetcher: offlineFetcher,
   });
 
   const txBuilder2 = new MeshTxBuilder({
@@ -297,7 +297,7 @@ describe("MeshTxBuilder - Duplicate Ref Input", () => {
       .votePlutusScriptV3()
       .vote(
         { type: "DRep", drepId: resolveScriptHashDRepId(alwaysSucceedHash) },
-        { txHash: txHash("tx100"), txIndex: 0 },
+        { txHash: txHash("tx101"), txIndex: 0 },
         { voteKind: "Yes" },
       )
       .voteTxInReference(txHash("tx3"), 0)

--- a/packages/mesh-transaction/test/mesh-tx-builder/script-tx.test.ts
+++ b/packages/mesh-transaction/test/mesh-tx-builder/script-tx.test.ts
@@ -1,6 +1,5 @@
 import {
   applyCborEncoding,
-  BlockfrostProvider,
   DRep,
   MeshTxBuilder,
   OfflineFetcher,
@@ -776,7 +775,6 @@ describe("MeshTxBuilder - Script Transactions", () => {
         "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
       )
       .complete();
-
     expect(
       await offlineEvaluator.evaluateTx(
         txHex,


### PR DESCRIPTION
## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [x] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [x] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

## Additional Information

This PR fixes issues with duplicated reference inputs. However, there is still one issue to be fixed, which is that spending inputs that have scripts attached results in the script size being counted twice for fee calculations. This is mainly because of how CSL worked previously, it wasn't possible to attach a script size to inputs (it is possible now, but we haven't refactored to account for this).

Because of this, there was a workaround where we attached the input both as a spending input and as a ref input. This causes slight issues in core-cst serialization. I will figure out the best way to fix this part and make another PR.
