### PR TITLE
Feature/resolve data hash for all types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29589,10 +29589,10 @@
     },
     "packages/hydra": {
       "name": "@meshsdk/hydra",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.26",
-        "@meshsdk/core-cst": "1.9.0-beta.26",
+        "@meshsdk/common": "1.9.0-beta.27",
+        "@meshsdk/core-cst": "1.9.0-beta.27",
         "axios": "^1.7.2"
       },
       "devDependencies": {
@@ -29605,7 +29605,7 @@
     },
     "packages/mesh-common": {
       "name": "@meshsdk/common",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
         "bech32": "^2.0.0",
@@ -29623,11 +29623,11 @@
     },
     "packages/mesh-contract": {
       "name": "@meshsdk/contract",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.26",
-        "@meshsdk/core": "1.9.0-beta.26"
+        "@meshsdk/common": "1.9.0-beta.27",
+        "@meshsdk/core": "1.9.0-beta.27"
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
@@ -29638,15 +29638,15 @@
     },
     "packages/mesh-core": {
       "name": "@meshsdk/core",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.26",
-        "@meshsdk/core-cst": "1.9.0-beta.26",
-        "@meshsdk/provider": "1.9.0-beta.26",
-        "@meshsdk/react": "1.9.0-beta.26",
-        "@meshsdk/transaction": "1.9.0-beta.26",
-        "@meshsdk/wallet": "1.9.0-beta.26"
+        "@meshsdk/common": "1.9.0-beta.27",
+        "@meshsdk/core-cst": "1.9.0-beta.27",
+        "@meshsdk/provider": "1.9.0-beta.27",
+        "@meshsdk/react": "1.9.0-beta.27",
+        "@meshsdk/transaction": "1.9.0-beta.27",
+        "@meshsdk/wallet": "1.9.0-beta.27"
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
@@ -29657,10 +29657,10 @@
     },
     "packages/mesh-core-csl": {
       "name": "@meshsdk/core-csl",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.26",
+        "@meshsdk/common": "1.9.0-beta.27",
         "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
         "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
         "@types/base32-encoding": "^1.0.2",
@@ -29670,7 +29670,7 @@
       },
       "devDependencies": {
         "@meshsdk/configs": "*",
-        "@meshsdk/provider": "1.9.0-beta.26",
+        "@meshsdk/provider": "1.9.0-beta.27",
         "@types/json-bigint": "^1.0.4",
         "eslint": "^8.57.0",
         "ts-jest": "^29.1.4",
@@ -29680,7 +29680,7 @@
     },
     "packages/mesh-core-cst": {
       "name": "@meshsdk/core-cst",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@cardano-sdk/core": "^0.45.5",
@@ -29689,7 +29689,7 @@
         "@harmoniclabs/cbor": "1.3.0",
         "@harmoniclabs/plutus-data": "1.2.4",
         "@harmoniclabs/uplc": "1.2.4",
-        "@meshsdk/common": "1.9.0-beta.26",
+        "@meshsdk/common": "1.9.0-beta.27",
         "@types/base32-encoding": "^1.0.2",
         "base32-encoding": "^1.0.0",
         "bech32": "^2.0.0",
@@ -29708,11 +29708,11 @@
     },
     "packages/mesh-provider": {
       "name": "@meshsdk/provider",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.26",
-        "@meshsdk/core-cst": "1.9.0-beta.26",
+        "@meshsdk/common": "1.9.0-beta.27",
+        "@meshsdk/core-cst": "1.9.0-beta.27",
         "@utxorpc/sdk": "0.6.2",
         "@utxorpc/spec": "0.10.1",
         "axios": "^1.7.2"
@@ -29727,13 +29727,13 @@
     },
     "packages/mesh-react": {
       "name": "@meshsdk/react",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@fabianbormann/cardano-peer-connect": "^1.2.18",
-        "@meshsdk/common": "1.9.0-beta.26",
-        "@meshsdk/transaction": "1.9.0-beta.26",
-        "@meshsdk/wallet": "1.9.0-beta.26",
+        "@meshsdk/common": "1.9.0-beta.27",
+        "@meshsdk/transaction": "1.9.0-beta.27",
+        "@meshsdk/wallet": "1.9.0-beta.27",
         "@meshsdk/web3-sdk": "0.0.17",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -29770,10 +29770,10 @@
     },
     "packages/mesh-svelte": {
       "name": "@meshsdk/svelte",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/core": "1.9.0-beta.26",
+        "@meshsdk/core": "1.9.0-beta.27",
         "bits-ui": "1.0.0-next.65"
       },
       "devDependencies": {
@@ -29799,11 +29799,11 @@
     },
     "packages/mesh-transaction": {
       "name": "@meshsdk/transaction",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.26",
-        "@meshsdk/core-cst": "1.9.0-beta.26",
+        "@meshsdk/common": "1.9.0-beta.27",
+        "@meshsdk/core-cst": "1.9.0-beta.27",
         "json-bigint": "^1.0.0"
       },
       "devDependencies": {
@@ -29816,12 +29816,12 @@
     },
     "packages/mesh-wallet": {
       "name": "@meshsdk/wallet",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@meshsdk/common": "1.9.0-beta.26",
-        "@meshsdk/core-cst": "1.9.0-beta.26",
-        "@meshsdk/transaction": "1.9.0-beta.26",
+        "@meshsdk/common": "1.9.0-beta.27",
+        "@meshsdk/core-cst": "1.9.0-beta.27",
+        "@meshsdk/transaction": "1.9.0-beta.27",
         "@simplewebauthn/browser": "^13.0.0"
       },
       "devDependencies": {
@@ -29834,7 +29834,7 @@
     },
     "scripts/mesh-cli": {
       "name": "meshjs",
-      "version": "1.9.0-beta.26",
+      "version": "1.9.0-beta.27",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "5.3.0",

--- a/packages/hydra/package.json
+++ b/packages/hydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/hydra",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Mesh Hydra package",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -27,8 +27,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.27",
-    "@meshsdk/core-cst": "1.9.0-beta.27",
+    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/core-cst": "1.9.0-beta.28",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Contains constants, types and interfaces used across the SDK and different serialization libraries",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-common/src/interfaces/serializer.ts
+++ b/packages/mesh-common/src/interfaces/serializer.ts
@@ -1,3 +1,4 @@
+import { PlutusDataType } from "../data";
 import {
   BuilderData,
   Data,
@@ -39,7 +40,10 @@ export interface IResolver {
     resolveTxHash(txHex: string): string;
   };
   data: {
-    resolveDataHash(data: Data): string;
+    resolveDataHash(
+      rawData: BuilderData["content"],
+      type?: PlutusDataType,
+    ): string;
   };
   script: {
     resolveScriptRef(script: NativeScript | PlutusScript): string;

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "List of open-source smart contracts, complete with documentation, live demos, and end-to-end source code. https://meshjs.dev/smart-contracts",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.27",
-    "@meshsdk/core": "1.9.0-beta.27"
+    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/core": "1.9.0-beta.28"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Types and utilities functions between Mesh and cardano-serialization-lib",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@meshsdk/configs": "*",
-    "@meshsdk/provider": "1.9.0-beta.27",
+    "@meshsdk/provider": "1.9.0-beta.28",
     "@types/json-bigint": "^1.0.4",
     "eslint": "^8.57.0",
     "ts-jest": "^29.1.4",
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.27",
+    "@meshsdk/common": "1.9.0-beta.28",
     "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
     "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
     "@types/base32-encoding": "^1.0.2",

--- a/packages/mesh-core-csl/src/core/serializer.ts
+++ b/packages/mesh-core-csl/src/core/serializer.ts
@@ -13,6 +13,7 @@ import type {
   IResolver,
   MeshTxBuilderBody,
   NativeScript,
+  PlutusDataType,
   PlutusScript,
   Protocol,
 } from "@meshsdk/common";
@@ -173,8 +174,11 @@ export class CSLSerializer implements IMeshTxSerializer {
       },
     },
     data: {
-      resolveDataHash: function (data: Data): string {
-        return resolveDataHash(data);
+      resolveDataHash: function (
+        rawData: BuilderData["content"],
+        type: PlutusDataType = "Mesh",
+      ): string {
+        return resolveDataHash(rawData, type);
       },
     },
     script: {

--- a/packages/mesh-core-csl/src/deser/converter.ts
+++ b/packages/mesh-core-csl/src/deser/converter.ts
@@ -214,7 +214,7 @@ export const castDataToPlutusData = ({
     return csl.PlutusData.from_hex(content as string);
   }
   return csl.PlutusData.from_json(
-    content as string,
+    castRawDataToJsonString(content),
     csl.PlutusDatumSchema.DetailedSchema,
   );
 };

--- a/packages/mesh-core-csl/src/deser/resolver.ts
+++ b/packages/mesh-core-csl/src/deser/resolver.ts
@@ -1,18 +1,19 @@
 import {
-  Data,
+  BuilderData,
   mnemonicToEntropy,
   NativeScript,
+  PlutusDataType,
   PlutusScript,
 } from "@meshsdk/common";
 
 import {
+  castDataToPlutusData,
   deserializePlutusScript,
   fromUTF8,
   toAddress,
   toBaseAddress,
   toBytes,
   toNativeScript,
-  toPlutusData,
   toRewardAddress,
   toScriptRef,
 } from ".";
@@ -118,8 +119,14 @@ export const resolveRewardAddress = (bech32: string) => {
   }
 };
 
-export const resolveDataHash = (data: Data) => {
-  const plutusData = toPlutusData(data);
+export const resolveDataHash = (
+  rawData: BuilderData["content"],
+  type: PlutusDataType = "Mesh",
+) => {
+  const plutusData = castDataToPlutusData({
+    content: rawData,
+    type,
+  } as BuilderData);
   const dataHash = csl.hash_plutus_data(plutusData);
   return dataHash.to_hex();
 };

--- a/packages/mesh-core-csl/test/utils/serializer.test.ts
+++ b/packages/mesh-core-csl/test/utils/serializer.test.ts
@@ -1,4 +1,9 @@
-import { applyCborEncoding, NativeScript } from "@meshsdk/core";
+import {
+  applyCborEncoding,
+  NativeScript,
+  serializeData,
+  stringToHex,
+} from "@meshsdk/core";
 
 import { CSLSerializer } from "../../src/core/serializer";
 
@@ -46,12 +51,30 @@ describe("CSLSerializer", () => {
     });
   });
 
-  it("should hash datum correctly", () => {
-    const datum = ["abc"];
-    const result = serializer.resolver.data.resolveDataHash(datum);
-    expect(result).toEqual(
-      "b52368c053c76240d861f42024266d14939934a9a30799cfd315ac34f75072e4",
-    );
+  describe("resolveDataHash", () => {
+    it("Mesh - should return correct data", () => {
+      expect(
+        serializer.resolver.data.resolveDataHash("supersecretdatum"),
+      ).toEqual(
+        "d786b11f300b0a7b4e0fe7931eb7871fb7ed762c0a060cd1f922dfa631cafb8c",
+      );
+    });
+    it("JSON - should return correct data", () => {
+      expect(
+        serializer.resolver.data.resolveDataHash(
+          { bytes: stringToHex("supersecretdatum") },
+          "JSON",
+        ),
+      ).toEqual(
+        "d786b11f300b0a7b4e0fe7931eb7871fb7ed762c0a060cd1f922dfa631cafb8c",
+      );
+    });
+    it("CBOR - should return correct data", () => {
+      const cbor = serializeData("supersecretdatum", "Mesh");
+      expect(serializer.resolver.data.resolveDataHash(cbor, "CBOR")).toEqual(
+        "d786b11f300b0a7b4e0fe7931eb7871fb7ed762c0a060cd1f922dfa631cafb8c",
+      );
+    });
   });
 
   it("should return correct script reference v3", () => {

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Types and utilities functions between Mesh and cardano-js-sdk",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -42,7 +42,7 @@
     "@harmoniclabs/cbor": "1.3.0",
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
-    "@meshsdk/common": "1.9.0-beta.27",
+    "@meshsdk/common": "1.9.0-beta.28",
     "@types/base32-encoding": "^1.0.2",
     "base32-encoding": "^1.0.0",
     "bech32": "^2.0.0",

--- a/packages/mesh-core-cst/src/resolvers/index.ts
+++ b/packages/mesh-core-cst/src/resolvers/index.ts
@@ -13,10 +13,11 @@ import base32 from "base32-encoding";
 import { bech32 } from "bech32";
 
 import {
-  Data,
+  BuilderData,
   fromUTF8,
   mnemonicToEntropy,
   NativeScript,
+  PlutusDataType,
   PlutusScript,
   toBytes,
 } from "@meshsdk/common";
@@ -32,19 +33,25 @@ import {
 import {
   deserializePlutusScript,
   deserializeTx,
+  fromBuilderToPlutusData,
   toAddress,
   toBaseAddress,
   toEnterpriseAddress,
   toNativeScript,
-  toPlutusData,
   toRewardAddress,
   toScriptRef,
 } from "../utils";
 import { buildRewardAddress } from "../utils/builder";
 import { hexToBytes } from "../utils/encoding";
 
-export const resolveDataHash = (data: Data) => {
-  const plutusData = toPlutusData(data);
+export const resolveDataHash = (
+  rawData: BuilderData["content"],
+  type: PlutusDataType = "Mesh",
+) => {
+  const plutusData = fromBuilderToPlutusData({
+    content: rawData,
+    type,
+  } as BuilderData);
   return plutusData.hash().toString();
 };
 

--- a/packages/mesh-core-cst/src/serializer/index.ts
+++ b/packages/mesh-core-cst/src/serializer/index.ts
@@ -39,6 +39,7 @@ import {
   MintItem,
   mnemonicToEntropy,
   Output,
+  PlutusDataType,
   PlutusScript,
   Protocol,
   PubKeyTxIn,
@@ -58,6 +59,7 @@ import {
   Withdrawal,
 } from "@meshsdk/common";
 
+import { resolveDataHash } from "..";
 import {
   Address,
   AddressType,
@@ -364,8 +366,11 @@ export class CardanoSDKSerializer implements IMeshTxSerializer {
       },
     },
     data: {
-      resolveDataHash: function (data: Data): string {
-        return fromBuilderToPlutusData({ type: "Mesh", content: data }).hash();
+      resolveDataHash: function (
+        rawData: BuilderData["content"],
+        type: PlutusDataType = "Mesh",
+      ): string {
+        return resolveDataHash(rawData, type);
       },
     },
     script: {

--- a/packages/mesh-core-cst/test/resolvers.test.ts
+++ b/packages/mesh-core-cst/test/resolvers.test.ts
@@ -4,7 +4,9 @@ import {
   PubKeyAddress,
   resolveFingerprint,
   ScriptAddress,
+  stringToHex,
 } from "@meshsdk/common";
+import { serializeData } from "@meshsdk/core";
 import {
   resolveDataHash,
   resolveNativeScriptAddress,
@@ -18,8 +20,21 @@ import {
 } from "@meshsdk/core-cst";
 
 describe("resolveDataHash", () => {
-  it("should return correct data", () => {
+  it("Mesh - should return correct data", () => {
     expect(resolveDataHash("supersecretdatum")).toEqual(
+      "d786b11f300b0a7b4e0fe7931eb7871fb7ed762c0a060cd1f922dfa631cafb8c",
+    );
+  });
+  it("JSON - should return correct data", () => {
+    expect(
+      resolveDataHash({ bytes: stringToHex("supersecretdatum") }, "JSON"),
+    ).toEqual(
+      "d786b11f300b0a7b4e0fe7931eb7871fb7ed762c0a060cd1f922dfa631cafb8c",
+    );
+  });
+  it("CBOR - should return correct data", () => {
+    const cbor = serializeData("supersecretdatum", "Mesh");
+    expect(resolveDataHash(cbor, "CBOR")).toEqual(
       "d786b11f300b0a7b4e0fe7931eb7871fb7ed762c0a060cd1f922dfa631cafb8c",
     );
   });

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Mesh SDK Core - https://meshjs.dev/",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,12 +33,12 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.27",
-    "@meshsdk/core-cst": "1.9.0-beta.27",
-    "@meshsdk/provider": "1.9.0-beta.27",
-    "@meshsdk/react": "1.9.0-beta.27",
-    "@meshsdk/transaction": "1.9.0-beta.27",
-    "@meshsdk/wallet": "1.9.0-beta.27"
+    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/core-cst": "1.9.0-beta.28",
+    "@meshsdk/provider": "1.9.0-beta.28",
+    "@meshsdk/react": "1.9.0-beta.28",
+    "@meshsdk/transaction": "1.9.0-beta.28",
+    "@meshsdk/wallet": "1.9.0-beta.28"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core/src/utils/resolver.ts
+++ b/packages/mesh-core/src/utils/resolver.ts
@@ -1,7 +1,9 @@
 import {
+  BuilderData,
   Data,
   LanguageVersion,
   NativeScript,
+  PlutusDataType,
   PlutusScript,
 } from "@meshsdk/common";
 
@@ -27,10 +29,14 @@ export const resolveTxHash = (txHex: string) => core.resolveTxHash(txHex);
 
 /**
  * Hash Cardano data
- * @param data Cardano data in Mesh Data type
+ * @param rawData Cardano data in Mesh, JSON or CBOR type
+ * @param type The data type, either Mesh, JSON or CBOR
  * @returns Cardano data hash
  */
-export const resolveDataHash = (data: Data) => core.resolveDataHash(data);
+export const resolveDataHash = (
+  rawData: BuilderData["content"],
+  type: PlutusDataType = "Mesh",
+) => core.resolveDataHash(rawData, type);
 
 /**
  * Hash Cardano native script

--- a/packages/mesh-core/src/utils/serializer.ts
+++ b/packages/mesh-core/src/utils/serializer.ts
@@ -117,7 +117,7 @@ export const serializeRewardAddress = (
  */
 export const serializeData = (
   rawData: BuilderData["content"],
-  type: Omit<PlutusDataType, "CBOR">,
+  type: Omit<PlutusDataType, "CBOR"> = "Mesh",
 ): string => {
   const serializer = new core.CardanoSDKSerializer();
   const builderData = {

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Blockchain data providers - https://meshjs.dev/providers",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.27",
-    "@meshsdk/core-cst": "1.9.0-beta.27",
+    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/core-cst": "1.9.0-beta.28",
     "@utxorpc/sdk": "0.6.2",
     "@utxorpc/spec": "0.10.1",
     "axios": "^1.7.2"

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "React component library - https://meshjs.dev/react",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@fabianbormann/cardano-peer-connect": "^1.2.18",
-    "@meshsdk/common": "1.9.0-beta.27",
-    "@meshsdk/transaction": "1.9.0-beta.27",
-    "@meshsdk/wallet": "1.9.0-beta.27",
+    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/transaction": "1.9.0-beta.28",
+    "@meshsdk/wallet": "1.9.0-beta.28",
     "@meshsdk/web3-sdk": "0.0.17",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/packages/mesh-svelte/package.json
+++ b/packages/mesh-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/svelte",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Svelte component library - https://meshjs.dev/svelte",
   "type": "module",
   "exports": {
@@ -26,7 +26,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "@meshsdk/core": "1.9.0-beta.27",
+    "@meshsdk/core": "1.9.0-beta.28",
     "bits-ui": "1.0.0-next.65"
   },
   "devDependencies": {

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Transactions - https://meshjs.dev/apis/transaction",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.27",
-    "@meshsdk/core-cst": "1.9.0-beta.27",
+    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/core-cst": "1.9.0-beta.28",
     "json-bigint": "^1.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "description": "Wallets - https://meshjs.dev/apis/wallets",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.27",
-    "@meshsdk/core-cst": "1.9.0-beta.27",
-    "@meshsdk/transaction": "1.9.0-beta.27",
+    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/core-cst": "1.9.0-beta.28",
+    "@meshsdk/transaction": "1.9.0-beta.28",
     "@simplewebauthn/browser": "^13.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your Web3 app using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.9.0-beta.27",
+  "version": "1.9.0-beta.28",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Improve `resolveDataHash` to accept all Mesh, JSON and CBOR type but not only Mesh type.

## Affect components

> Please indicate which part of the Mesh Repo

- [X] `@meshsdk/common`
- [X] `@meshsdk/core`
- [X] `@meshsdk/core-csl`
- [X] `@meshsdk/core-cst`

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [X] New feature (non-breaking change which adds functionality)

