### PR TITLE
parse errors for mesh tx builder eval

### DIFF
--- a/packages/mesh-transaction/src/mesh-tx-builder/index.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/index.ts
@@ -502,9 +502,23 @@ export class MeshTxBuilder extends MeshTxBuilderCore {
           this.meshTxBuilderBody.chainedTxs,
         )
         .catch((error) => {
-          throw new Error(
-            `Tx evaluation failed: ${error.message} \n For txHex: ${txHex}`,
-          );
+          if (error instanceof Error) {
+            throw new Error(
+              `Tx evaluation failed: ${error.message} \n For txHex: ${txHex}`,
+            );
+          } else if (typeof error === "string") {
+            throw new Error(
+              `Tx evaluation failed: ${error} \n For txHex: ${txHex}`,
+            );
+          } else if (typeof error === "object") {
+            throw new Error(
+              `Tx evaluation failed: ${JSON.stringify(error)} \n For txHex: ${txHex}`,
+            );
+          } else {
+            throw new Error(
+              `Tx evaluation failed: ${String(error)} \n For txHex: ${txHex}`,
+            );
+          }
         });
       this.updateRedeemer(this.meshTxBuilderBody, txEvaluation);
       txHex = this.serializer.serializeTxBody(


### PR DESCRIPTION
## Summary

The error message from Blockfrost provider is of type string, which does not have a `.message` field. I have changed the error handling of MeshTxBuilder to handle different types of errors from the evaluator. But it may be better to either ensure all errors returned by everything is of type `Error`. Or extract an error handling layer.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [x] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

> Please add the related issue here if any

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)
