### PR TITLE
Add addSerializedTransaction function to OfflineFetcher

### DIFF
--- a/apps/playground/src/pages/about/about-us/hero.tsx
+++ b/apps/playground/src/pages/about/about-us/hero.tsx
@@ -4,7 +4,7 @@ export default function AboutHero() {
       <div className="z-1 relative mx-auto max-w-screen-xl px-4 py-8 text-white lg:py-16">
         <div className="mb-6 max-w-screen-lg lg:mb-0">
           <h1 className="mb-4 text-4xl font-extrabold leading-none tracking-tight md:text-5xl lg:text-6xl">
-            We advance the Web3 tech stack
+            We advance the Cardano's tech stack
           </h1>
           <p className="mb-6 font-light text-neutral-400 md:text-lg lg:mb-8 lg:text-xl">
             Get started building blockchain applications with our
@@ -13,7 +13,6 @@ export default function AboutHero() {
             wallet integrations to data service providers, building a Web3
             application has never been this easy.
           </p>
-
           {/* <a
             href="#"
             className="bg-primary-700 hover:bg-primary-800 focus:ring-primary-900 dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800 inline-flex items-center rounded-lg px-5 py-3 text-center font-medium text-white focus:outline-none focus:ring-4"

--- a/apps/playground/src/pages/providers/offline-fetcher.tsx
+++ b/apps/playground/src/pages/providers/offline-fetcher.tsx
@@ -26,6 +26,8 @@ const ReactPage: NextPage = () => {
   let code1 = `import { OfflineFetcher } from "@meshsdk/core";\n\n`;
   code1 += `// Create a new instance\n`;
   code1 += `const fetcher = new OfflineFetcher();\n`;
+  code1 += `// Create with specified network\n`;
+  code1 += `const fetcherWithNetwork = new OfflineFetcher("mainnet");\n`;
 
   let code2 = `// Add account information\n`;
   code2 += `fetcher.addAccount("addr1...", {\n`;
@@ -74,7 +76,9 @@ const ReactPage: NextPage = () => {
   code2 += `  poolDeposit: 500000000,\n`;
   code2 += `  minPoolCost: "340000000",\n`;
   code2 += `  // Other parameters...\n`;
-  code2 += `});\n`;
+  code2 += `});\n\n`;
+  code2 += `// Add serilized transaction\n`;
+  code2 += `fetcher.addSerializedTransaction("txHash");\n\n`;
 
   let code3 = `// Save state\n`;
   code3 += `const state = fetcher.toJSON();\n`;

--- a/packages/hydra/package.json
+++ b/packages/hydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/hydra",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Mesh Hydra package",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -27,8 +27,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.28",
-    "@meshsdk/core-cst": "1.9.0-beta.28",
+    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/core-cst": "1.9.0-beta.29",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/hydra/package.json
+++ b/packages/hydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/hydra",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Mesh Hydra package",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -27,8 +27,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.29",
-    "@meshsdk/core-cst": "1.9.0-beta.29",
+    "@meshsdk/common": "1.9.0-beta.30",
+    "@meshsdk/core-cst": "1.9.0-beta.30",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Contains constants, types and interfaces used across the SDK and different serialization libraries",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Contains constants, types and interfaces used across the SDK and different serialization libraries",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "List of open-source smart contracts, complete with documentation, live demos, and end-to-end source code. https://meshjs.dev/smart-contracts",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.28",
-    "@meshsdk/core": "1.9.0-beta.28"
+    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/core": "1.9.0-beta.29"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "List of open-source smart contracts, complete with documentation, live demos, and end-to-end source code. https://meshjs.dev/smart-contracts",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.29",
-    "@meshsdk/core": "1.9.0-beta.29"
+    "@meshsdk/common": "1.9.0-beta.30",
+    "@meshsdk/core": "1.9.0-beta.30"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Types and utilities functions between Mesh and cardano-serialization-lib",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@meshsdk/configs": "*",
-    "@meshsdk/provider": "1.9.0-beta.29",
+    "@meshsdk/provider": "1.9.0-beta.30",
     "@types/json-bigint": "^1.0.4",
     "eslint": "^8.57.0",
     "ts-jest": "^29.1.4",
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/common": "1.9.0-beta.30",
     "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
     "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
     "@types/base32-encoding": "^1.0.2",

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Types and utilities functions between Mesh and cardano-serialization-lib",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@meshsdk/configs": "*",
-    "@meshsdk/provider": "1.9.0-beta.28",
+    "@meshsdk/provider": "1.9.0-beta.29",
     "@types/json-bigint": "^1.0.4",
     "eslint": "^8.57.0",
     "ts-jest": "^29.1.4",
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/common": "1.9.0-beta.29",
     "@sidan-lab/sidan-csl-rs-browser": "0.9.21",
     "@sidan-lab/sidan-csl-rs-nodejs": "0.9.21",
     "@types/base32-encoding": "^1.0.2",

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Types and utilities functions between Mesh and cardano-js-sdk",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -42,7 +42,7 @@
     "@harmoniclabs/cbor": "1.3.0",
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
-    "@meshsdk/common": "1.9.0-beta.28",
+    "@meshsdk/common": "1.9.0-beta.29",
     "@types/base32-encoding": "^1.0.2",
     "base32-encoding": "^1.0.0",
     "bech32": "^2.0.0",

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Types and utilities functions between Mesh and cardano-js-sdk",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -42,7 +42,7 @@
     "@harmoniclabs/cbor": "1.3.0",
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
-    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/common": "1.9.0-beta.30",
     "@types/base32-encoding": "^1.0.2",
     "base32-encoding": "^1.0.0",
     "bech32": "^2.0.0",

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Mesh SDK Core - https://meshjs.dev/",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,12 +33,12 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.28",
-    "@meshsdk/core-cst": "1.9.0-beta.28",
-    "@meshsdk/provider": "1.9.0-beta.28",
-    "@meshsdk/react": "1.9.0-beta.28",
-    "@meshsdk/transaction": "1.9.0-beta.28",
-    "@meshsdk/wallet": "1.9.0-beta.28"
+    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/core-cst": "1.9.0-beta.29",
+    "@meshsdk/provider": "1.9.0-beta.29",
+    "@meshsdk/react": "1.9.0-beta.29",
+    "@meshsdk/transaction": "1.9.0-beta.29",
+    "@meshsdk/wallet": "1.9.0-beta.29"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Mesh SDK Core - https://meshjs.dev/",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,12 +33,12 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.29",
-    "@meshsdk/core-cst": "1.9.0-beta.29",
-    "@meshsdk/provider": "1.9.0-beta.29",
-    "@meshsdk/react": "1.9.0-beta.29",
-    "@meshsdk/transaction": "1.9.0-beta.29",
-    "@meshsdk/wallet": "1.9.0-beta.29"
+    "@meshsdk/common": "1.9.0-beta.30",
+    "@meshsdk/core-cst": "1.9.0-beta.30",
+    "@meshsdk/provider": "1.9.0-beta.30",
+    "@meshsdk/react": "1.9.0-beta.30",
+    "@meshsdk/transaction": "1.9.0-beta.30",
+    "@meshsdk/wallet": "1.9.0-beta.30"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Blockchain data providers - https://meshjs.dev/providers",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.28",
-    "@meshsdk/core-cst": "1.9.0-beta.28",
+    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/core-cst": "1.9.0-beta.29",
     "@utxorpc/sdk": "0.6.2",
     "@utxorpc/spec": "0.10.1",
     "axios": "^1.7.2"

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Blockchain data providers - https://meshjs.dev/providers",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.29",
-    "@meshsdk/core-cst": "1.9.0-beta.29",
+    "@meshsdk/common": "1.9.0-beta.30",
+    "@meshsdk/core-cst": "1.9.0-beta.30",
     "@utxorpc/sdk": "0.6.2",
     "@utxorpc/spec": "0.10.1",
     "axios": "^1.7.2"

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "React component library - https://meshjs.dev/react",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@fabianbormann/cardano-peer-connect": "^1.2.18",
-    "@meshsdk/common": "1.9.0-beta.28",
-    "@meshsdk/transaction": "1.9.0-beta.28",
-    "@meshsdk/wallet": "1.9.0-beta.28",
+    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/transaction": "1.9.0-beta.29",
+    "@meshsdk/wallet": "1.9.0-beta.29",
     "@meshsdk/web3-sdk": "0.0.17",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "React component library - https://meshjs.dev/react",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@fabianbormann/cardano-peer-connect": "^1.2.18",
-    "@meshsdk/common": "1.9.0-beta.29",
-    "@meshsdk/transaction": "1.9.0-beta.29",
-    "@meshsdk/wallet": "1.9.0-beta.29",
+    "@meshsdk/common": "1.9.0-beta.30",
+    "@meshsdk/transaction": "1.9.0-beta.30",
+    "@meshsdk/wallet": "1.9.0-beta.30",
     "@meshsdk/web3-sdk": "0.0.17",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/packages/mesh-svelte/package.json
+++ b/packages/mesh-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/svelte",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Svelte component library - https://meshjs.dev/svelte",
   "type": "module",
   "exports": {
@@ -26,7 +26,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "@meshsdk/core": "1.9.0-beta.29",
+    "@meshsdk/core": "1.9.0-beta.30",
     "bits-ui": "1.0.0-next.65"
   },
   "devDependencies": {

--- a/packages/mesh-svelte/package.json
+++ b/packages/mesh-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/svelte",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Svelte component library - https://meshjs.dev/svelte",
   "type": "module",
   "exports": {
@@ -26,7 +26,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "@meshsdk/core": "1.9.0-beta.28",
+    "@meshsdk/core": "1.9.0-beta.29",
     "bits-ui": "1.0.0-next.65"
   },
   "devDependencies": {

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Transactions - https://meshjs.dev/apis/transaction",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.29",
-    "@meshsdk/core-cst": "1.9.0-beta.29",
+    "@meshsdk/common": "1.9.0-beta.30",
+    "@meshsdk/core-cst": "1.9.0-beta.30",
     "json-bigint": "^1.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Transactions - https://meshjs.dev/apis/transaction",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.28",
-    "@meshsdk/core-cst": "1.9.0-beta.28",
+    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/core-cst": "1.9.0-beta.29",
     "json-bigint": "^1.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "description": "Wallets - https://meshjs.dev/apis/wallets",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.28",
-    "@meshsdk/core-cst": "1.9.0-beta.28",
-    "@meshsdk/transaction": "1.9.0-beta.28",
+    "@meshsdk/common": "1.9.0-beta.29",
+    "@meshsdk/core-cst": "1.9.0-beta.29",
+    "@meshsdk/transaction": "1.9.0-beta.29",
     "@simplewebauthn/browser": "^13.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "description": "Wallets - https://meshjs.dev/apis/wallets",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.29",
-    "@meshsdk/core-cst": "1.9.0-beta.29",
-    "@meshsdk/transaction": "1.9.0-beta.29",
+    "@meshsdk/common": "1.9.0-beta.30",
+    "@meshsdk/core-cst": "1.9.0-beta.30",
+    "@meshsdk/transaction": "1.9.0-beta.30",
     "@simplewebauthn/browser": "^13.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your Web3 app using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.9.0-beta.28",
+  "version": "1.9.0-beta.29",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your Web3 app using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.9.0-beta.29",
+  "version": "1.9.0-beta.30",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
# Summary
This PR adds a new `addSerializedTransaction` function to the OfflineFetcher class in the Mesh SDK. This function allows users to add a serialized transaction (in CBOR hex format) to the fetcher, which generates pseudo blocks, removes spent UTxOs, and adds new UTxOs from the transaction. This enhancement makes the OfflineFetcher more versatile for testing and offline development workflows.

# Affected components
- [x] `@meshsdk/provider`
- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [x] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

# Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

# Related Issues
<!-- Please add the related issue here if any -->
N/A

# Checklist
- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)