### PR TITLE
feat: support filtering UTxOs by txHash and outputIndex

### DIFF
--- a/packages/mesh-hydra/src/hydra-provider.ts
+++ b/packages/mesh-hydra/src/hydra-provider.ts
@@ -127,8 +127,22 @@ export class HydraProvider implements IFetcher, ISubmitter {
    * @param index
    * @returns - Array of UTxOs
    */
-  async fetchUTxOs(): Promise<UTxO[]> {
-    return await this.subscribeSnapshotUtxo();
+  async fetchUTxOs(hash?: string, index?: number): Promise<UTxO[]> {
+    const snapshotUTxOs = await this.subscribeSnapshotUtxo();
+
+    const outputsPromises: Promise<UTxO>[] = [];
+    snapshotUTxOs.forEach((utxo) => {
+      if (hash === undefined || utxo.input.txHash === hash) {
+        outputsPromises.push(Promise.resolve(utxo));
+      }
+    });
+    const outputs = await Promise.all(outputsPromises);
+
+    if (index !== undefined) {
+      return outputs.filter((utxo) => utxo.input.outputIndex === index);
+    }
+
+    return outputs;
   }
 
   /**


### PR DESCRIPTION
> Thank you for contributing to Mesh! We appreciate your effort and dedication to improving this project. To ensure that your contribution is in line with the project's guidelines and can be reviewed efficiently, please fill out the template below.

> Remember to follow our [Contributing Guide](CONTRIBUTING.md) before submitting your pull request.

## Summary

This pull request enhances the fetchUTxOs() function to support optional filtering by txHash and outputIndex.
Previously, the method returned all UTxOs from the snapshot. With this update, developers can now retrieve a specific UTxO (or multiple matching ones) by providing a transaction hash and optionally an output index.
This improves flexibility and efficiency when querying UTxOs, especially for constructing transactions.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [x] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (improving code quality without changing its behavior)
- [x] Documentation update (adding or updating documentation related to the project)

## Related Issues

> Please add the related issue here if any

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

## Additional Information

This change introduces no breaking behavior. It simply provides an optional and backward-compatible enhancement to an existing utility function in the Hydra module.
