### PR TITLE
refactor: improve scriptHash calculation and add scriptRef to UTxO

### DIFF
--- a/packages/mesh-hydra/src/types/hUTxOs.ts
+++ b/packages/mesh-hydra/src/types/hUTxOs.ts
@@ -1,6 +1,7 @@
 import { UTxO } from "@meshsdk/common";
 import { hAssets } from "./hAssets";
 import { hReferenceScript } from "./hReferenceScript";
+import { resolveScriptHash } from "@meshsdk/core";
 
 export type hUTxOs = {
   [txRef: string]: hUTxO;
@@ -39,6 +40,7 @@ hUTxO.toUTxO = (hUTxO: hUTxO, txId: string): UTxO => {
   if (!txHash || !txIndex) {
     throw new Error("Invalid txId format");
   }
+  const scriptRef = hUTxO.referenceScript?.script?.cborHex;
   return {
     input: {
       outputIndex: Number(txIndex),
@@ -49,7 +51,8 @@ hUTxO.toUTxO = (hUTxO: hUTxO, txId: string): UTxO => {
       amount: hAssets.toAssets(hUTxO.value),
       dataHash: hUTxO.datumhash ?? undefined,
       plutusData: hUTxO.inlineDatum?.toString(),
-      scriptHash: hUTxO.referenceScript?.toString(),
+      scriptHash: scriptRef ? resolveScriptHash(scriptRef, "V3") : undefined,
+      scriptRef: scriptRef,
     },
   };
 }


### PR DESCRIPTION
> Thank you for contributing to Mesh! We appreciate your effort and dedication to improving this project. To ensure that your contribution is in line with the project's guidelines and can be reviewed efficiently, please fill out the template below.

> Remember to follow our [Contributing Guide](CONTRIBUTING.md) before submitting your pull request.

## Summary

This pull request improves the hUTxO.toUTxO() function by accurately computing the scriptHash from the CBOR hex of the Plutus V3 script and adding the scriptRef field to the resulting UTxO.

Previously, the script hash was derived using .toString(), which might not yield a valid hash required for contract execution. By switching to resolveScriptHash(scriptRef, "V3"), we ensure that the script hash is consistent with on-chain expectations. Additionally, the returned UTxO now includes the actual script reference (scriptRef), which is required when submitting reference script-based transactions.

These changes make the UTxO structure more robust and compatible with Plutus V3 and reference script workflows.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

> Please add the related issue here if any

## Checklist

> Please ensure that your pull request meets the following criteria:

- [ ] My code is appropriately commented and includes relevant documentation, if necessary
- [ ] I have added tests to cover my changes, if necessary
- [ ] I have updated the documentation, if necessary
- [ ] All new and existing tests pass (i.e. `npm run test`)
- [ ] The build is pass (i.e. `npm run build`)

## Additional Information

This change does not introduce breaking behavior. It ensures the returned UTxO data is structurally accurate and consistent for Plutus smart contract transactions involving reference scripts.
