### PR TITLE
fix DOM invalid property 

### DIFF
--- a/packages/mesh-svelte/src/lib/cardano-wallet-dropdown/component/cardano-wallet-dropdown-button.svelte
+++ b/packages/mesh-svelte/src/lib/cardano-wallet-dropdown/component/cardano-wallet-dropdown-button.svelte
@@ -80,9 +80,9 @@
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
         d="M19 9l-7 7-7-7"
       />
     </svg>


### PR DESCRIPTION
## Summary

When using CardanoWallet react component, I was getting this error and decided to investigate it
<img width="856" height="306" alt="image" src="https://github.com/user-attachments/assets/6383bc88-0df2-48c3-81f5-e67567db7ec3" />

## Affect components
 
- [x] `@meshsdk/react`
- [x] `@meshsdk/svelte` 

## Type of Change
 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)
 
## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)
 
