### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Compare versions
         id: compare-versions
         run: |
-          if [[ "${{ steps.pre-merge-version.outputs.core_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.core_post_merge_version }}" ]]; then
+          if [[ "${{ steps.pre-merge-version.outputs.pre_merge_version }}" != "${{ steps.post-merge-version.outputs.post_merge_version }}" ]]; then
               echo "core-version-updated=true" >> "$GITHUB_OUTPUT"
           else
               echo "core-version-updated=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,19 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     outputs:
-      bitcoin-version-updated: ${{ steps.compare-versions.outputs.bitcoin-version-updated }}
-      hydra-version-updated: ${{ steps.compare-versions.outputs.hydra-version-updated }}
-      common-version-updated: ${{ steps.compare-versions.outputs.common-version-updated }}
-      contract-version-updated: ${{ steps.compare-versions.outputs.contract-version-updated }}
-      core-version-updated: ${{ steps.compare-versions.outputs.core-version-updated }}
-      core-csl-version-updated: ${{ steps.compare-versions.outputs.core-csl-version-updated }}
-      core-cst-version-updated: ${{ steps.compare-versions.outputs.core-cst-version-updated }}
-      provider-version-updated: ${{ steps.compare-versions.outputs.provider-version-updated }}
-      react-version-updated: ${{ steps.compare-versions.outputs.react-version-updated }}
-      svelte-version-updated: ${{ steps.compare-versions.outputs.svelte-version-updated }}
-      transaction-version-updated: ${{ steps.compare-versions.outputs.transaction-version-updated }}
-      wallet-version-updated: ${{ steps.compare-versions.outputs.wallet-version-updated }}
-      cli-version-updated: ${{ steps.compare-versions.outputs.cli-version-updated }}
+      version-updated: ${{ steps.compare-versions.outputs.version-updated }}
     steps:
       - name: Checkout main branch at commit before merge
         uses: actions/checkout@v4
@@ -53,33 +41,8 @@ jobs:
       - name: Get package version from main branch before merge
         id: pre-merge-version
         run: |
-          BITCOIN_PRE_MERGE_VERSION=$(node -p "require('./packages/bitcoin/package.json').version")
-          HYDRA_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-hydra/package.json').version")
-          COMMON_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-common/package.json').version")
-          CONTRACT_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-contract/package.json').version")
-          CORE_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-core/package.json').version")
-          CORE_CSL_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-core-csl/package.json').version")
-          CORE_CST_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-core-cst/package.json').version")
-          PROVIDER_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-core-cst/package.json').version")
-          REACT_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-react/package.json').version")
-          SVELTE_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-svelte/package.json').version")
-          TRANSACTION_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-transaction/package.json').version")
-          WALLET_PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-wallet/package.json').version")
-          CLI_PRE_MERGE_VERSION=$(node -p "require('./scripts/mesh-cli/package.json').version")
-          
-          echo "bitcoin_pre_merge_version=$BITCOIN_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "hydra_pre_merge_version=$HYDRA_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "common_pre_merge_version=$COMMON_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "contract_pre_merge_version=$CONTRACT_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "core_pre_merge_version=$CORE_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "core_csl_pre_merge_version=$CORE_CSL_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "core_cst_pre_merge_version=$CORE_CST_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "provider_pre_merge_version=$PROVIDER_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "react_pre_merge_version=$REACT_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "svelte_pre_merge_version=$SVELTE_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "transaction_pre_merge_version=$TRANSACTION_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "wallet_pre_merge_version=$WALLET_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "cli_pre_merge_version=$CLI_PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
+          PRE_MERGE_VERSION=$(node -p "require('./packages/mesh-core/package.json').version")
+          echo "pre_merge_version=$PRE_MERGE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Checkout main branch at commit after merge
         uses: actions/checkout@v4
@@ -89,106 +52,21 @@ jobs:
       - name: Get package version from main branch after merge
         id: post-merge-version
         run: |
-          BITCOIN_POST_MERGE_VERSION=$(node -p "require('./packages/bitcoin/package.json').version")
-          HYDRA_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-hydra/package.json').version")
-          COMMON_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-common/package.json').version")
-          CONTRACT_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-contract/package.json').version")
-          CORE_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-core/package.json').version")
-          CORE_CSL_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-core-csl/package.json').version")
-          CORE_CST_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-core-cst/package.json').version")
-          PROVIDER_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-core-cst/package.json').version")
-          REACT_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-react/package.json').version")
-          SVELTE_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-svelte/package.json').version")
-          TRANSACTION_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-transaction/package.json').version")
-          WALLET_POST_MERGE_VERSION=$(node -p "require('./packages/mesh-wallet/package.json').version")
-          CLI_POST_MERGE_VERSION=$(node -p "require('./scripts/mesh-cli/package.json').version")
-          
-          echo "bitcoin_post_merge_version=$BITCOIN_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "hydra_post_merge_version=$HYDRA_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "common_post_merge_version=$COMMON_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "contract_post_merge_version=$CONTRACT_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "core_post_merge_version=$CORE_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "core_csl_post_merge_version=$CORE_CSL_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "core_cst_post_merge_version=$CORE_CST_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "provider_post_merge_version=$PROVIDER_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "react_post_merge_version=$REACT_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "svelte_post_merge_version=$SVELTE_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "transaction_post_merge_version=$TRANSACTION_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "wallet_post_merge_version=$WALLET_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "cli_post_merge_version=$CLI_POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
+          POST_MERGE_VERSION=$(node -p "require('./packages/mesh-core/package.json').version")
+          echo "post_merge_version=$POST_MERGE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Compare versions
         id: compare-versions
         run: |
-          if [[ "${{ steps.pre-merge-version.outputs.bitcoin_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.bitcoin_post_merge_version }}" ]]; then
-              echo "bitcoin-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "bitcoin-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.hydra_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.hydra_post_merge_version }}" ]]; then
-              echo "hydra-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "hydra-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.common_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.common_post_merge_version }}" ]]; then
-              echo "common-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "common-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.contract_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.contract_post_merge_version }}" ]]; then
-              echo "contract-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "contract-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
           if [[ "${{ steps.pre-merge-version.outputs.core_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.core_post_merge_version }}" ]]; then
               echo "core-version-updated=true" >> "$GITHUB_OUTPUT"
           else
               echo "core-version-updated=false" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{ steps.pre-merge-version.outputs.core_csl_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.core_csl_post_merge_version }}" ]]; then
-              echo "core-csl-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "core-csl-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.core_cst_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.core_cst_post_merge_version }}" ]]; then
-              echo "core-cst-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "core-cst-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.provider_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.provider_post_merge_version }}" ]]; then
-              echo "provider-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "provider-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.react_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.react_post_merge_version }}" ]]; then
-              echo "react-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "react-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.svelte_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.svelte_post_merge_version }}" ]]; then
-              echo "svelte-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "svelte-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.transaction_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.transaction_post_merge_version }}" ]]; then
-              echo "transaction-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "transaction-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.wallet_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.wallet_post_merge_version }}" ]]; then
-              echo "wallet-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "wallet-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ steps.pre-merge-version.outputs.cli_pre_merge_version }}" != "${{ steps.post-merge-version.outputs.cli_post_merge_version }}" ]]; then
-              echo "cli-version-updated=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "cli-version-updated=false" >> "$GITHUB_OUTPUT"
-          fi
 
   publish-meshsdk-bitcoin:
     needs: [build, check-version]
-    if: needs.check-version.outputs.bitcoin-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -203,7 +81,7 @@ jobs:
 
   publish-meshsdk-hydra:
     needs: [build, check-version]
-    if: needs.check-version.outputs.hydra-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -215,10 +93,10 @@ jobs:
       - run: cd packages/mesh-hydra && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-  
+
   publish-meshsdk-common:
     needs: [build, check-version]
-    if: needs.check-version.outputs.common-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -233,7 +111,7 @@ jobs:
 
   publish-meshsdk-contract:
     needs: [build, check-version]
-    if: needs.check-version.outputs.contract-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -248,7 +126,7 @@ jobs:
 
   publish-meshsdk-core:
     needs: [build, check-version]
-    if: needs.check-version.outputs.core-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -263,7 +141,7 @@ jobs:
 
   publish-meshsdk-core-csl:
     needs: [build, check-version]
-    if: needs.check-version.outputs.core-csl-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -278,7 +156,7 @@ jobs:
 
   publish-meshsdk-core-cst:
     needs: [build, check-version]
-    if: needs.check-version.outputs.core-cst-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -293,7 +171,7 @@ jobs:
 
   publish-meshsdk-provider:
     needs: [build, check-version]
-    if: needs.check-version.outputs.provider-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -308,7 +186,7 @@ jobs:
 
   publish-meshsdk-react:
     needs: [build, check-version]
-    if: needs.check-version.outputs.react-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -323,7 +201,7 @@ jobs:
 
   publish-meshsdk-svelte:
     needs: [build, check-version]
-    if: needs.check-version.outputs.svelte-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -338,7 +216,7 @@ jobs:
 
   publish-meshsdk-transaction:
     needs: [build, check-version]
-    if: needs.check-version.outputs.transaction-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -353,7 +231,7 @@ jobs:
 
   publish-meshsdk-wallet:
     needs: [build, check-version]
-    if: needs.check-version.outputs.wallet-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -368,7 +246,7 @@ jobs:
 
   publish-meshsdk-cli:
     needs: [build, check-version]
-    if: needs.check-version.outputs.cli-version-updated == 'true'
+    if: needs.check-version.outputs.version-updated == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,9 +59,9 @@ jobs:
         id: compare-versions
         run: |
           if [[ "${{ steps.pre-merge-version.outputs.pre_merge_version }}" != "${{ steps.post-merge-version.outputs.post_merge_version }}" ]]; then
-              echo "core-version-updated=true" >> "$GITHUB_OUTPUT"
+              echo "version-updated=true" >> "$GITHUB_OUTPUT"
           else
-              echo "core-version-updated=false" >> "$GITHUB_OUTPUT"
+              echo "version-updated=false" >> "$GITHUB_OUTPUT"
           fi
 
   publish-meshsdk-bitcoin:

--- a/packages/bitcoin/package.json
+++ b/packages/bitcoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/bitcoin",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Mesh Bitcoin package",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-common/package.json
+++ b/packages/mesh-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/common",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Contains constants, types and interfaces used across the SDK and different serialization libraries",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/packages/mesh-contract/package.json
+++ b/packages/mesh-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/contract",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "List of open-source smart contracts, complete with documentation, live demos, and end-to-end source code. https://meshjs.dev/smart-contracts",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -34,8 +34,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.72",
-    "@meshsdk/core": "1.9.0-beta.72"
+    "@meshsdk/common": "1.9.0-beta.73",
+    "@meshsdk/core": "1.9.0-beta.73"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-core-csl/package.json
+++ b/packages/mesh-core-csl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-csl",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Types and utilities functions between Mesh and cardano-serialization-lib",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@meshsdk/configs": "*",
-    "@meshsdk/provider": "1.9.0-beta.72",
+    "@meshsdk/provider": "1.9.0-beta.73",
     "@types/json-bigint": "^1.0.4",
     "eslint": "^8.57.0",
     "ts-jest": "^29.1.4",
@@ -39,7 +39,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.72",
+    "@meshsdk/common": "1.9.0-beta.73",
     "@sidan-lab/whisky-js-browser": "^1.0.9",
     "@sidan-lab/whisky-js-nodejs": "^1.0.9",
     "@types/base32-encoding": "^1.0.2",

--- a/packages/mesh-core-cst/package.json
+++ b/packages/mesh-core-cst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core-cst",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Types and utilities functions between Mesh and cardano-js-sdk",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -44,7 +44,7 @@
     "@harmoniclabs/plutus-data": "1.2.4",
     "@harmoniclabs/uplc": "1.2.4",
     "@harmoniclabs/pair": "^1.0.0",
-    "@meshsdk/common": "1.9.0-beta.72",
+    "@meshsdk/common": "1.9.0-beta.73",
     "@types/base32-encoding": "^1.0.2",
     "base32-encoding": "^1.0.0",
     "bech32": "^2.0.0",

--- a/packages/mesh-core/package.json
+++ b/packages/mesh-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/core",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Mesh SDK Core - https://meshjs.dev/",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -33,12 +33,12 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.72",
-    "@meshsdk/core-cst": "1.9.0-beta.72",
-    "@meshsdk/provider": "1.9.0-beta.72",
-    "@meshsdk/react": "1.9.0-beta.72",
-    "@meshsdk/transaction": "1.9.0-beta.72",
-    "@meshsdk/wallet": "1.9.0-beta.72"
+    "@meshsdk/common": "1.9.0-beta.73",
+    "@meshsdk/core-cst": "1.9.0-beta.73",
+    "@meshsdk/provider": "1.9.0-beta.73",
+    "@meshsdk/react": "1.9.0-beta.73",
+    "@meshsdk/transaction": "1.9.0-beta.73",
+    "@meshsdk/wallet": "1.9.0-beta.73"
   },
   "prettier": "@meshsdk/configs/prettier",
   "publishConfig": {

--- a/packages/mesh-hydra/package.json
+++ b/packages/mesh-hydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/hydra",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Mesh Hydra package",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -27,8 +27,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.72",
-    "@meshsdk/core-cst": "1.9.0-beta.72",
+    "@meshsdk/common": "1.9.0-beta.73",
+    "@meshsdk/core-cst": "1.9.0-beta.73",
     "axios": "^1.7.2"
   },
   "devDependencies": {

--- a/packages/mesh-provider/package.json
+++ b/packages/mesh-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/provider",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Blockchain data providers - https://meshjs.dev/providers",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.72",
-    "@meshsdk/core-cst": "1.9.0-beta.72",
+    "@meshsdk/common": "1.9.0-beta.73",
+    "@meshsdk/core-cst": "1.9.0-beta.73",
     "@utxorpc/sdk": "^0.6.7",
     "@utxorpc/spec": "^0.16.0",
     "axios": "^1.7.2",

--- a/packages/mesh-react/package.json
+++ b/packages/mesh-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/react",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "React component library - https://meshjs.dev/react",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "@fabianbormann/cardano-peer-connect": "^1.2.18",
-    "@meshsdk/bitcoin": "1.9.0-beta.72",
-    "@meshsdk/common": "1.9.0-beta.72",
-    "@meshsdk/transaction": "1.9.0-beta.72",
-    "@meshsdk/wallet": "1.9.0-beta.72",
+    "@meshsdk/bitcoin": "1.9.0-beta.73",
+    "@meshsdk/common": "1.9.0-beta.73",
+    "@meshsdk/transaction": "1.9.0-beta.73",
+    "@meshsdk/wallet": "1.9.0-beta.73",
     "@meshsdk/web3-sdk": "0.0.50",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/packages/mesh-svelte/package.json
+++ b/packages/mesh-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/svelte",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Svelte component library - https://meshjs.dev/svelte",
   "type": "module",
   "exports": {
@@ -26,7 +26,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
-    "@meshsdk/core": "1.9.0-beta.72",
+    "@meshsdk/core": "1.9.0-beta.73",
     "bits-ui": "1.0.0-next.65"
   },
   "devDependencies": {

--- a/packages/mesh-transaction/package.json
+++ b/packages/mesh-transaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/transaction",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Transactions - https://meshjs.dev/apis/transaction",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,8 +35,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.72",
-    "@meshsdk/core-cst": "1.9.0-beta.72",
+    "@meshsdk/common": "1.9.0-beta.73",
+    "@meshsdk/core-cst": "1.9.0-beta.73",
     "@cardano-sdk/core": "^0.45.5",
     "@cardano-sdk/util": "^0.15.5",
     "@cardano-sdk/input-selection": "^0.13.33",

--- a/packages/mesh-wallet/package.json
+++ b/packages/mesh-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/wallet",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "description": "Wallets - https://meshjs.dev/apis/wallets",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",
@@ -35,9 +35,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@meshsdk/common": "1.9.0-beta.72",
-    "@meshsdk/core-cst": "1.9.0-beta.72",
-    "@meshsdk/transaction": "1.9.0-beta.72",
+    "@meshsdk/common": "1.9.0-beta.73",
+    "@meshsdk/core-cst": "1.9.0-beta.73",
+    "@meshsdk/transaction": "1.9.0-beta.73",
     "@simplewebauthn/browser": "^13.0.0"
   },
   "prettier": "@meshsdk/configs/prettier",

--- a/scripts/mesh-cli/package.json
+++ b/scripts/mesh-cli/package.json
@@ -3,7 +3,7 @@
   "description": "A quick and easy way to bootstrap your Web3 app using Mesh.",
   "homepage": "https://meshjs.dev",
   "author": "MeshJS",
-  "version": "1.9.0-beta.72",
+  "version": "1.9.0-beta.73",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
This pull request simplifies and standardizes the version comparison and publishing logic in the GitHub Actions workflow for the monorepo. The workflow now checks only the `mesh-core` package version to determine if any publish jobs should run, instead of tracking version changes for each individual package. All package versions and internal dependencies have also been bumped to `1.9.0-beta.73`.

Key changes:

**GitHub Actions workflow simplification:**

* The `.github/workflows/publish.yml` workflow now checks only `mesh-core`'s version to determine whether to trigger publishing for all packages, replacing individual version checks for each package. This reduces complexity and maintenance overhead. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L34-R34) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L56-R45) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L92-R69)
* All publish jobs (`publish-meshsdk-*`) now use a unified `version-updated` output, instead of checking separate outputs for each package. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L206-R84) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L221-R99) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L236-R114) [[4]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L251-R129) [[5]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L266-R144) [[6]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L281-R159) [[7]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L296-R174) [[8]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L311-R189) [[9]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L326-R204) [[10]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L341-R219) [[11]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L356-R234) [[12]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L371-R249)

**Version bumps:**

* All package versions are updated from `1.9.0-beta.72` to `1.9.0-beta.73`. [[1]](diffhunk://#diff-4e236459592d40f5ab907d5885509a035f7ab320185ae5f5c20e788e0d8dbbbcL3-R3) [[2]](diffhunk://#diff-43fc9a7e51f448b6a0aa8720088e0b550d0d522f973ba29243cb18af0daa7434L3-R3) [[3]](diffhunk://#diff-c73d78f917d2dc7bdcf4a9e0b81bfacabde0b6123dadc78d0838471e04baa134L3-R3) [[4]](diffhunk://#diff-757c6ec5b908803789c8c3d82a4371f28e43e6d7ccbdb47172c8a1f27f1a04abL3-R3) [[5]](diffhunk://#diff-c0ecb9aca16e4662a8510bd241c8ad5196c7bec7dd7e9d0424cb1e7a399d6d62L3-R3)
* Internal dependencies within the packages are updated to reference the new version (`1.9.0-beta.73`). [[1]](diffhunk://#diff-c73d78f917d2dc7bdcf4a9e0b81bfacabde0b6123dadc78d0838471e04baa134L37-R38) [[2]](diffhunk://#diff-757c6ec5b908803789c8c3d82a4371f28e43e6d7ccbdb47172c8a1f27f1a04abL34-R42) [[3]](diffhunk://#diff-c0ecb9aca16e4662a8510bd241c8ad5196c7bec7dd7e9d0424cb1e7a399d6d62L47-R47)

These changes make the release process easier to maintain by centralizing version checks and ensure all packages and their dependencies are aligned to the latest version.