### PR TITLE
Feature update/wallet hex apis

### DIFF
--- a/packages/mesh-wallet/src/mesh/index.ts
+++ b/packages/mesh-wallet/src/mesh/index.ts
@@ -253,7 +253,7 @@ export class MeshWallet implements IWallet {
     if (this.addresses.baseAddress && addressType === "payment") {
       return this.addresses.baseAddress.toBytes().toString();
     }
-    return this.addresses.enterpriseAddress.toBytes().toString();
+    return this.addresses.enterpriseAddress!.toBytes().toString();
   }
 
   /**

--- a/packages/mesh-wallet/test/mesh.test.ts
+++ b/packages/mesh-wallet/test/mesh.test.ts
@@ -26,6 +26,9 @@ describe("MeshWallet", () => {
     expect(await wallet.getChangeAddress()).toEqual(
       "addr_test1qpvx0sacufuypa2k4sngk7q40zc5c4npl337uusdh64kv0uafhxhu32dys6pvn6wlw8dav6cmp4pmtv7cc3yel9uu0nq93swx9",
     );
+    expect(await wallet.getChangeAddressHex()).toEqual(
+      "005867c3b8e27840f556ac268b781578b14c5661fc63ee720dbeab663f9d4dcd7e454d2434164f4efb8edeb358d86a1dad9ec6224cfcbce3e6",
+    );
   });
 
   it("stake key sign tx", async () => {


### PR DESCRIPTION
## Summary

Our APIs have been designed with the aspiration of being easy to use, and so there are times when the return types are not very useful for more advanced users who wish for APIs that need it to conform to standards. I have added some extra APIs for users who would like to receive the hex format for addresses, or UTxOs from the MeshWallet instance.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [ ] `@meshsdk/transaction`
- [x] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

> Please add the related issue here if any

## Checklist

> Please ensure that your pull request meets the following criteria:

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

