### PR TITLE
Fix/koios evaluator response 610

### DIFF
--- a/packages/mesh-provider/src/koios.ts
+++ b/packages/mesh-provider/src/koios.ts
@@ -659,11 +659,13 @@ export class KoiosProvider
       });
 
       if (status === 200 || status === 202) {
-        if (!data.result || !data.result.length) {
+        if (!data.result) {
           return [];
         }
 
-        return data.result.map((val: any) => {
+        // Koios Ogmios endpoint returns result as an object, not an array
+        // Use Object.values() to convert to array, matching Ogmios provider behavior
+        return Object.values(data.result).map((val: any) => {
           if (!val.validator || !val.budget) {
             throw new Error("Invalid response format");
           }


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Koios provider's `evaluateTx` method where the response from the Koios Ogmios endpoint was incorrectly handled. The Koios Ogmios endpoint returns the evaluation result as an **object** (matching the native Ogmios provider format), but the code was treating it as an **array**, causing evaluation failures or incorrect results.

**Problem:**
- The code checked `data.result.length` and used `data.result.map()` directly, assuming `result` was an array
- This caused issues when the Ogmios endpoint returned an object response

**Solution:**
- Changed the response handling to use `Object.values(data.result)` to convert the object to an array before mapping
- Removed the `.length` check since objects don't have a `length` property
- Added a comment explaining why `Object.values()` is used, matching the pattern from the Ogmios provider implementation

This fix ensures the Koios provider correctly implements `IEvaluator` and can be used with `MeshTxBuilder` for transaction evaluation.

## Affect components

- [x] `@meshsdk/provider`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

- Closes #610

## Checklist

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

## Additional Information

### Changes Made:

**File: `packages/mesh-provider/src/koios.ts`**

1. **Line 662**: Changed from `if (!data.result || !data.result.length)` to `if (!data.result)`
   - Removed the `.length` check since `result` is an object, not an array

2. **Line 666**: Changed from `return data.result.map(...)` to `return Object.values(data.result).map(...)`
   - Converts the object response to an array before mapping, matching the Ogmios provider pattern

3. **Added comment**: Explains why `Object.values()` is used to handle the object response format

### Technical Details:

The Koios API provides an Ogmios-compatible endpoint at `/ogmios` that returns evaluation results in the same format as the native Ogmios provider. The response structure is:

{
  "result": {
    "0": { "validator": {...}, "budget": {...} },
    "1": { "validator": {...}, "budget": {...} }
  }
}
