### PR TITLE
fix: use provider-supplied cost models in script integrity hash

### DIFF
--- a/packages/mesh-common/src/types/protocol.ts
+++ b/packages/mesh-common/src/types/protocol.ts
@@ -1,5 +1,11 @@
 import { DEFAULT_PROTOCOL_PARAMETERS } from "../constants";
 
+export type CostModels = {
+  PlutusV1?: number[];
+  PlutusV2?: number[];
+  PlutusV3?: number[];
+};
+
 export type Protocol = {
   epoch: number;
   minFeeA: number;
@@ -22,12 +28,14 @@ export type Protocol = {
   maxCollateralInputs: number;
   coinsPerUtxoSize: number;
   minFeeRefScriptCostPerByte: number;
+  costModels?: CostModels;
 };
 
 export const castProtocol = (
   data: Partial<Record<keyof Protocol, any>>,
 ): Protocol => {
-  const result: Partial<Record<keyof Protocol, number | string>> = {};
+  const result: Partial<Record<keyof Protocol, number | string | CostModels>> =
+    {};
 
   for (const rawKey in DEFAULT_PROTOCOL_PARAMETERS) {
     const key = rawKey as keyof Protocol;
@@ -38,6 +46,10 @@ export const castProtocol = (
     } else if (typeof defaultValue === "string") {
       result[key] = !value && value !== "" ? defaultValue : value.toString();
     }
+  }
+
+  if (data.costModels && typeof data.costModels === "object") {
+    result.costModels = data.costModels as CostModels;
   }
 
   return result as Protocol;

--- a/packages/mesh-common/test/types/protocol.test.ts
+++ b/packages/mesh-common/test/types/protocol.test.ts
@@ -75,5 +75,19 @@ describe("Protocol", () => {
       expect(casted.epoch).toBe(correct.epoch);
       expect(casted.decentralisation).toBe(correct.decentralisation);
     });
+
+    it("should preserve costModels when provided", () => {
+      const v3 = [100788, 420, 1, 1, 1000];
+      const casted = castProtocol({ costModels: { PlutusV3: v3 } });
+
+      expect(casted.costModels).toBeDefined();
+      expect(casted.costModels?.PlutusV3).toEqual(v3);
+    });
+
+    it("should leave costModels undefined when not provided", () => {
+      const casted = castProtocol({ minFeeA: 44 });
+
+      expect(casted.costModels).toBeUndefined();
+    });
   });
 });

--- a/packages/mesh-core-cst/src/serializer/index.ts
+++ b/packages/mesh-core-cst/src/serializer/index.ts
@@ -1528,15 +1528,15 @@ class CardanoSDKSerializerCore {
 
     // After building tx witness set, we must hash it with the cost models
     // and put the hash in the tx body
-    let costModelV1 = Serialization.CostModel.newPlutusV1(
-      DEFAULT_V1_COST_MODEL_LIST,
-    );
-    let costModelV2 = Serialization.CostModel.newPlutusV2(
-      DEFAULT_V2_COST_MODEL_LIST,
-    );
-    let costModelV3 = Serialization.CostModel.newPlutusV3(
-      DEFAULT_V3_COST_MODEL_LIST,
-    );
+    let v1CostList =
+      this.protocolParams.costModels?.PlutusV1 ?? DEFAULT_V1_COST_MODEL_LIST;
+    let v2CostList =
+      this.protocolParams.costModels?.PlutusV2 ?? DEFAULT_V2_COST_MODEL_LIST;
+    let v3CostList =
+      this.protocolParams.costModels?.PlutusV3 ?? DEFAULT_V3_COST_MODEL_LIST;
+    let costModelV1 = Serialization.CostModel.newPlutusV1(v1CostList);
+    let costModelV2 = Serialization.CostModel.newPlutusV2(v2CostList);
+    let costModelV3 = Serialization.CostModel.newPlutusV3(v3CostList);
     let costModels = new Serialization.Costmdls();
 
     if (this.usedLanguages[PlutusLanguageVersion.V1]) {


### PR DESCRIPTION
## Summary

Fixes the `PPViewHashesDontMatch` failure on Plutus V3 mints submitted to preprod and preview, and prevents the same failure from hitting mainnet once the PV11 hard fork is enacted.

The `CardanoSDKSerializerCore` was hashing scripts with the hardcoded `DEFAULT_V[123]_COST_MODEL_LIST` from `@meshsdk/common`, regardless of the protocol parameters supplied to the serializer. This PR makes the serializer prefer cost models from `protocolParams.costModels` when present, falling back to the hardcoded defaults otherwise. Backwards compatible — existing callers that pass a `Protocol` without `costModels` keep current behavior.

See #824 for the full root cause analysis and on-chain verification.

## Affect components

- [x] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [x] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [ ] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Related Issues

Closes #824

## Checklist

- [x] My code is appropriately commented and includes relevant documentation, if necessary
- [x] I have added tests to cover my changes, if necessary
- [x] I have updated the documentation, if necessary
- [x] All new and existing tests pass (i.e. `npm run test`)
- [x] The build is pass (i.e. `npm run build`)

## Additional Information

End-to-end verified on Cardano preprod with a CIP-68 mint that was previously failing with `PPViewHashesDontMatch`:

https://preprod.cardanoscan.io/transaction/2dc2622f2adc08da0b1b698f7e000ea2085a2e54ac33a64ab38b5b6aeed2aa52

### Changes

- Add optional `CostModels` type and `Protocol.costModels` field in `@meshsdk/common`.
- `castProtocol` passes the `costModels` object through when present.
- `CardanoSDKSerializerCore` reads cost models from `protocolParams.costModels?.PlutusV[123]` when available, falls back to `DEFAULT_V[123]_COST_MODEL_LIST` otherwise.
- Two new tests in `protocol.test.ts` covering presence/absence of `costModels` on `castProtocol`.

### Notes for reviewers

- New local variables use `let` to match the surrounding style in `CardanoSDKSerializerCore` (the function declares similar locals with `let` even when not reassigned).
- No JSDoc added on `CostModels` or `Protocol.costModels`, to match the existing convention in `protocol.ts` (no type-level JSDoc on `Protocol`, `Asset`, `PoolParams`, etc.).
- Pre-existing test suite failures on `main` (6 in `@meshsdk/common`, 5 in `@meshsdk/core-cst` — module resolution issues unrelated to cost models) are unaffected by this PR. Verified by running tests on `main` and on this branch with identical fail/pass counts (only difference: +2 new passing tests in `protocol.test.ts`).