### PR TITLE
fix: preserve Map (and bigint) in cloneOutput via structuredClone

### DIFF
--- a/packages/mesh-transaction/src/mesh-tx-builder/index.ts
+++ b/packages/mesh-transaction/src/mesh-tx-builder/index.ts
@@ -1861,7 +1861,10 @@ function tierRefScriptFee(
 }
 
 export const cloneOutput = (output: Output): Output => {
-  return JSONBig.parse(JSONBig.stringify(output));
+  // structuredClone preserves Map, bigint and nested Mesh Data objects, which a
+  // JSON round-trip silently drops (e.g. a Map in an inline datum becomes `{}`).
+  // See https://github.com/MeshJS/mesh/issues/704
+  return structuredClone(output);
 };
 
 export const setLoveLace = (output: Output, lovelace: bigint): Output => {

--- a/packages/mesh-transaction/test/clone-output.test.ts
+++ b/packages/mesh-transaction/test/clone-output.test.ts
@@ -1,0 +1,83 @@
+import { Output } from "@meshsdk/common";
+
+import { cloneOutput } from "../src";
+
+// Regression tests for https://github.com/MeshJS/mesh/issues/704
+// cloneOutput previously used a JSON round-trip, which silently drops Map
+// entries and mangles bigint values inside Mesh `Data` inline datums (e.g.
+// CIP-68 metadata produced by metadataToCip68), causing
+// "Cannot convert undefined to a BigInt" during serializeOutput.
+describe("cloneOutput", () => {
+  it("preserves a Map inside a Mesh Data inline datum", () => {
+    const metadata = new Map<string, string>([
+      ["name", "Mesh Token"],
+      ["image", "ipfs://Qm..."],
+    ]);
+
+    const output: Output = {
+      address: "addr_test1vqld...",
+      amount: [{ unit: "lovelace", quantity: "2000000" }],
+      datum: {
+        type: "Inline",
+        data: {
+          type: "Mesh",
+          // CIP-68-style constructor: { alternative, fields: [Map, version] }
+          content: { alternative: 0, fields: [metadata, 1n] },
+        },
+      },
+    };
+
+    const cloned = cloneOutput(output);
+    const clonedContent = cloned.datum!.data.content as {
+      alternative: number;
+      fields: unknown[];
+    };
+    const clonedMap = clonedContent.fields[0] as Map<string, string>;
+
+    // The Map must survive cloning (JSON would have produced an empty object).
+    // Use the toStringTag rather than `instanceof` so the assertion is robust to
+    // the cross-realm Map that structuredClone yields inside the jest VM.
+    expect(Object.prototype.toString.call(clonedMap)).toBe("[object Map]");
+    expect(clonedMap.size).toBe(2);
+    expect(clonedMap.get("name")).toBe("Mesh Token");
+    expect(clonedMap.get("image")).toBe("ipfs://Qm...");
+
+    // bigint must survive (JSON.stringify throws on / coerces bigint).
+    expect(clonedContent.fields[1]).toBe(1n);
+    expect(typeof clonedContent.fields[1]).toBe("bigint");
+  });
+
+  it("returns a deep copy that is independent of the original", () => {
+    const output: Output = {
+      address: "addr_test1vqld...",
+      amount: [
+        { unit: "lovelace", quantity: "2000000" },
+        { unit: "abc123", quantity: "5" },
+      ],
+      datum: {
+        type: "Inline",
+        data: { type: "Mesh", content: { alternative: 0, fields: [42n] } },
+      },
+    };
+
+    const cloned = cloneOutput(output);
+
+    // Structurally equal...
+    expect(cloned).toEqual(output);
+    // ...but not the same references (mutating the clone must not touch source).
+    expect(cloned).not.toBe(output);
+    expect(cloned.amount).not.toBe(output.amount);
+
+    cloned.amount[0]!.quantity = "999";
+    expect(output.amount[0]!.quantity).toBe("2000000");
+  });
+
+  it("clones a plain ADA-only output", () => {
+    const output: Output = {
+      address: "addr_test1vqld...",
+      amount: [{ unit: "lovelace", quantity: "1500000" }],
+    };
+
+    expect(cloneOutput(output)).toEqual(output);
+  });
+});


### PR DESCRIPTION
## Summary

`cloneOutput` deep-cloned outputs via a JSON round-trip (`JSONBig.parse(JSONBig.stringify(...))`), which silently drops `Map` entries (and mangles `bigint`) inside a Mesh `Data` inline datum. When an inline datum contains a `Map` — e.g. CIP-68 metadata produced by `metadataToCip68` and used with `.txOutInlineDatumValue(..., "Mesh")` — the `Map` was cloned to an empty `{}`, and serialization later threw `TypeError: Cannot convert undefined to a BigInt` in `toPlutusData`.

This switches `cloneOutput` to `structuredClone`, which preserves `Map`, `bigint`, `Uint8Array` and nested structures. It's also consistent with how the tx builder already clones `txOutput` and other queue items in `tx-builder-core.ts`.

Fixes #704

## Root cause

`packages/mesh-transaction/src/mesh-tx-builder/index.ts` — `cloneOutput` is called by `getOutputMinLovelace` on every min-ADA calculation, so any output whose inline datum holds a `Map` was corrupted during transaction building.

```ts
// before
export const cloneOutput = (output: Output): Output => {
  return JSONBig.parse(JSONBig.stringify(output));
};
// after
export const cloneOutput = (output: Output): Output => {
  return structuredClone(output);
};
```

## Tests

Adds `packages/mesh-transaction/test/clone-output.test.ts`:
- a `Map` inside a Mesh `Data` inline datum survives cloning (size + entries),
- `bigint` fields survive,
- the clone is a deep, independent copy,
- plain ADA-only outputs are unaffected.

All existing `@meshsdk/transaction` tests pass (24 suites / 128 tests); `tsc --noEmit` clean; prettier clean.

## Credit

Thanks to @Daennes for the precise diagnosis and for suggesting `structuredClone` in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
