### PR TITLE
Reject malformed UTxO output indexes

### DIFF
--- a/packages/mesh-core-csl/src/utils/transaction-parser.ts
+++ b/packages/mesh-core-csl/src/utils/transaction-parser.ts
@@ -20,9 +20,14 @@ export const getRequiredInputs = (transactionHex: string): TxInput[] => {
         `Invalid UTxO format: ${utxoStr}. Expected format is txHash#outputIndex`,
       );
     }
+    if (!/^\d+$/.test(outputIndex)) {
+      throw new Error(
+        `Invalid UTxO output index: ${outputIndex}. Expected a nonnegative integer`,
+      );
+    }
     return {
       txHash: txHash,
-      outputIndex: parseInt(outputIndex),
+      outputIndex: Number(outputIndex),
     };
   });
 };

--- a/packages/mesh-core-csl/test/utils/transaction-parser.test.ts
+++ b/packages/mesh-core-csl/test/utils/transaction-parser.test.ts
@@ -1,0 +1,39 @@
+import { js_get_required_inputs_to_resolve } from "@sidan-lab/whisky-js-nodejs";
+
+import { getRequiredInputs } from "../../src/utils/transaction-parser";
+
+jest.mock("@sidan-lab/whisky-js-nodejs", () => ({
+  js_get_required_inputs_to_resolve: jest.fn(),
+}));
+
+const mockedGetRequiredInputs = jest.mocked(js_get_required_inputs_to_resolve);
+
+const mockRequiredInputs = (data: string[]) => {
+  mockedGetRequiredInputs.mockReturnValue({
+    get_status: () => "success",
+    get_error: () => "",
+    get_data: () => JSON.stringify(data),
+  } as ReturnType<typeof js_get_required_inputs_to_resolve>);
+};
+
+describe("getRequiredInputs", () => {
+  beforeEach(() => {
+    mockedGetRequiredInputs.mockReset();
+  });
+
+  test("rejects malformed output indexes", () => {
+    mockRequiredInputs(["txhash#1abc"]);
+
+    expect(() => getRequiredInputs("txhex")).toThrow(
+      "Invalid UTxO output index: 1abc",
+    );
+  });
+
+  test("parses nonnegative integer output indexes", () => {
+    mockRequiredInputs(["txhash#12"]);
+
+    expect(getRequiredInputs("txhex")).toEqual([
+      { txHash: "txhash", outputIndex: 12 },
+    ]);
+  });
+});


### PR DESCRIPTION
`getRequiredInputs` parsed UTxO output indexes with `parseInt`, so values like `1abc` were accepted as `1`.

This validates the parsed output index as a decimal nonnegative integer before converting it, and adds coverage for malformed and valid indexes.